### PR TITLE
【fix】application.html.erb内のパーシャル名を修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
     <% if user_signed_in? %>
       <%= render "shared/footer_signed_in" %>
     <% else %>
-      <%= render "shared/_footer" %>
+      <%= render "shared/footer" %>
     <% end %>
   </body>
 </html>


### PR DESCRIPTION
- [x] application.html.erb内のパーシャル名を間違えており、デプロイ後にエラー発生したため、修正した