### PR TITLE
【feat】MoodLogモデルの作成及び関連付け

### DIFF
--- a/app/models/feeling.rb
+++ b/app/models/feeling.rb
@@ -1,5 +1,7 @@
 class Feeling < ApplicationRecord
+  # --- 関連 ---
   has_many :mood_logs, dependent: :nullify
 
+  # --- バリデーション ---
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -1,6 +1,8 @@
 class Mood < ApplicationRecord
+  # --- 関連 ---
   has_many :mood_logs, dependent: :nullify
 
+  # --- バリデーション ---
   validates :score, presence: true, uniqueness: true
   validates :label, presence: true, uniqueness: true
   validates :color, presence: true

--- a/app/models/mood_log.rb
+++ b/app/models/mood_log.rb
@@ -1,0 +1,27 @@
+class MoodLog < ApplicationRecord
+  # recorded_atのデフォルト値を現在時刻に設定（マイグレーションのdefaultオプションはDB側で設定されるため、validationエラーを防ぐ目的でモデル側でも設定）
+  before_validation :set_default_recorded_at, on: :create
+  # --- 関連 ---
+  belongs_to :user
+  belongs_to :mood
+  belongs_to :habit_log, optional: true
+  belongs_to :feeling, optional: true
+
+  # --- バリデーション ---
+  validates :user_id, :mood_id, :recorded_at, presence: true
+
+  # --- スコープ ---
+  scope :today, -> { where(recorded_at: Time.zone.today.all_day) } # Time.currentではall_dayが使用できないため、Time.zone.todayを採用
+  scope :recent, -> { order(recorded_at: :desc) }
+
+  # --- インスタンスメソッド ---
+  def mood_label
+    mood.label
+  end
+
+  private
+
+  def set_default_recorded_at
+    self.recorded_at ||= Time.current
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  # --- 関連 ---
+  has_many :mood_logs, dependent: :destroy
 end

--- a/db/migrate/20251029100343_create_mood_logs.rb
+++ b/db/migrate/20251029100343_create_mood_logs.rb
@@ -1,0 +1,18 @@
+class CreateMoodLogs < ActiveRecord::Migration[7.2]
+  def change
+    create_table :mood_logs do |t|
+      # --- 必須（null: false） ---
+      t.references :user,        null: false, foreign_key: true
+      t.references :mood,        null: false, foreign_key: true
+      t.datetime   :recorded_at, null: false, default: -> { 'CURRENT_TIMESTAMP' }
+
+      # --- 任意（null: true） ---
+      # t.references :habit_log,   null: true, foreign_key: true 将来追加
+      t.references :feeling,     null: true, foreign_key: true
+      t.string     :timing,      null: true
+      t.text       :note,        null: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_29_050306) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_29_100343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,20 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_050306) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_feelings_on_name", unique: true
+  end
+
+  create_table "mood_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "mood_id", null: false
+    t.datetime "recorded_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.bigint "feeling_id"
+    t.string "timing"
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feeling_id"], name: "index_mood_logs_on_feeling_id"
+    t.index ["mood_id"], name: "index_mood_logs_on_mood_id"
+    t.index ["user_id"], name: "index_mood_logs_on_user_id"
   end
 
   create_table "moods", force: :cascade do |t|
@@ -43,4 +57,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_29_050306) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "mood_logs", "feelings"
+  add_foreign_key "mood_logs", "moods"
+  add_foreign_key "mood_logs", "users"
 end


### PR DESCRIPTION
## 概要
MoodLog（気分記録）モデルを作成し、
User / Mood / Feeling モデルと関連付けを実装。

## 実装理由
ユーザーの気分を日単位で記録・分析できる基盤を整えるため。
今後、ホーム画面での気分登録機能（絵文字クリック→記録）に利用

## 対応Issue
close #36 