### PR TITLE
【fix】気分ログの登録時刻変更がうまくできない問題を修正

### DIFF
--- a/app/controllers/mood_logs_controller.rb
+++ b/app/controllers/mood_logs_controller.rb
@@ -52,6 +52,6 @@ def update
 end
 
   def mood_log_params
-    params.require(:mood_log).permit(:mood_id, :feeling_id, :note, :logged_at)
+    params.require(:mood_log).permit(:mood_id, :feeling_id, :note, :recorded_at)
   end
 end

--- a/app/models/mood_log.rb
+++ b/app/models/mood_log.rb
@@ -1,6 +1,7 @@
 class MoodLog < ApplicationRecord
   # recorded_atのデフォルト値を現在時刻に設定（マイグレーションのdefaultオプションはDB側で設定されるため、validationエラーを防ぐ目的でモデル側でも設定）
   before_validation :set_default_recorded_at, on: :create
+  before_validation :truncate_recorded_at_to_minute
   # --- 関連 ---
   belongs_to :user
   belongs_to :mood
@@ -23,5 +24,11 @@ class MoodLog < ApplicationRecord
 
   def set_default_recorded_at
     self.recorded_at ||= Time.current
+  end
+
+  # 秒以下を切り捨てて、HTMLバリデーションと整合を取る
+  def truncate_recorded_at_to_minute
+    return if recorded_at.blank?
+    self.recorded_at = recorded_at.change(sec: 0, usec: 0)
   end
 end

--- a/app/views/mood_logs/_modal_form.html.erb
+++ b/app/views/mood_logs/_modal_form.html.erb
@@ -48,8 +48,8 @@
             <!-- 記録日時 -->
             <div class="form-control">
               <%= f.label :recorded_at, "記録日時", class: "label-text font-semibold text-base-content/80" %>
-              <%= f.datetime_field :recorded_at,
-                                    class: "input input-bordered w-full text-sm" %>
+              <%= f.datetime_local_field :recorded_at,
+                                          class: "input input-bordered w-full text-sm" %>
             </div>
           </div>
 


### PR DESCRIPTION
## 🕒 概要
`記録日時（recorded_at）` フィールドで発生していた  
「有効な値を入力してください」エラーを修正しました。  

Rails 側で秒以下を切り捨てて保存するように変更し、  
ブラウザの `datetime-local` フィールドと完全に整合するようにしました。  

---

## 💡 実装理由
- `datetime-local` フィールドでは `step` 属性（刻み幅）に合わない秒数が含まれると  
  「有効な値を入力してください」というHTML5バリデーションエラーが発生するため。  
- Railsの`recorded_at`が秒やミリ秒を含んで保存されていたため、  
  編集時に再表示するとブラウザがその値を不正と判定していた。  
- ユーザーが時刻を再編集しやすいよう、常に分単位で扱うように統一。

---