### PR TITLE
【feat】気分記録の削除機能実装

### DIFF
--- a/app/controllers/mood_logs_controller.rb
+++ b/app/controllers/mood_logs_controller.rb
@@ -27,29 +27,52 @@ class MoodLogsController < ApplicationController
     end
   end
 
-def update
-  @mood_log = current_user.mood_logs.find(params[:id])
+  def update
+    @mood_log = current_user.mood_logs.find(params[:id])
 
-  if @mood_log.update(mood_log_params)
-    flash.now[:notice] = "気分を更新しました。"
     respond_to do |format|
-      format.turbo_stream
-      format.html { redirect_back fallback_location: home_path, notice: "気分を更新しました。" }
-    end
-  else
-    respond_to do |format|
-      format.turbo_stream do
+      if @mood_log.update(mood_log_params)
+        flash.now[:notice] = "気分記録を更新しました。"
+        format.turbo_stream
+        format.html { redirect_back fallback_location: home_path, notice: "気分記録を更新しました。" }
+      else
         flash.now[:alert] = "更新に失敗しました。"
-        render turbo_stream: turbo_stream.replace(
-          "modal",
-          partial: "mood_logs/form",
-          locals: { mood_log: @mood_log }
-        )
+
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "modal",
+            partial: "mood_logs/form",
+            locals: { mood_log: @mood_log }
+          )
+        end
+        format.html { redirect_back fallback_location: home_path, alert: "更新に失敗しました。" }
       end
-      format.html { redirect_back fallback_location: home_path, alert: "更新に失敗しました。" }
     end
   end
-end
+
+  def destroy
+    @mood_log = current_user.mood_logs.find(params[:id])
+
+    respond_to do |format|
+      if @mood_log.destroy
+        flash.now[:notice] = "気分記録を削除しました。"
+
+        format.turbo_stream
+        format.html { redirect_back fallback_location: home_path, notice: "気分記録を削除しました。" }
+      else
+        flash.now[:alert] = "削除に失敗しました。"
+
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(
+            "modal",
+            partial: "mood_logs/form",
+            locals: { mood_log: @mood_log }
+          )
+        end
+        format.html { redirect_back fallback_location: home_path, alert: "削除に失敗しました。" }
+      end
+    end
+  end
 
   def mood_log_params
     params.require(:mood_log).permit(:mood_id, :feeling_id, :note, :recorded_at)

--- a/app/views/mood_logs/_modal_form.html.erb
+++ b/app/views/mood_logs/_modal_form.html.erb
@@ -59,7 +59,7 @@
           <!-- アクションボタン -->
           <div class="modal-action flex justify-between items-center pt-4 border-t border-base-300">
             <div class="flex gap-2">
-              <%= f.submit "更新する", class: "btn btn-sm btn-primary h-9 min-h-9 px-4" %>
+              <%= f.submit "更新", class: "btn btn-sm btn-primary h-9 min-h-9 px-4" %>
               <%= link_to "削除",
                           mood_log_path(@mood_log),
                           data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },

--- a/app/views/mood_logs/_modal_show.html.erb
+++ b/app/views/mood_logs/_modal_show.html.erb
@@ -39,12 +39,10 @@
                       class: "btn btn-sm btn-outline btn-primary h-9 min-h-9 px-4",
                       data: { turbo_frame: "modal", turbo_prefetch: "false" } %>
 
-          <%= button_to "削除",
-                        mood_log_path(mood_log),
-                        method: :delete,
-                        data: { turbo_confirm: "本当に削除しますか？" },
-                        class: "btn btn-sm btn-outline btn-error h-9 min-h-9 px-4",
-                        form: { class: "inline-block m-0 p-0" } %>
+          <%= link_to "削除",
+                          mood_log_path(@mood_log),
+                          data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+                          class: "btn btn-sm btn-outline btn-error h-9 min-h-9 px-4" %>
         </div>
 
         <button type="button"

--- a/app/views/mood_logs/destroy.turbo_stream.erb
+++ b/app/views/mood_logs/destroy.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.remove dom_id(@mood_log) %>
+
+<%#= turbo_stream.replace "flash", partial: "shared/flash" %>
+
+<!-- replaceを使うとタグごと消えてモーダルが開けなくなるためupdateを使用 -->
+<%= turbo_stream.update "modal", "" %> <!-- モーダルの中身を空にする -->


### PR DESCRIPTION
## 概要
気分ログの **削除機能** を新たに実装しました。  
Turbo Stream に対応しており、削除後はページ全体を再読み込みせず、対象カードのみを即時にDOMから削除します。

## 実装理由
これまで気分ログを削除する手段がなく、誤って記録した内容を修正できない状態でした。  
削除機能を追加することで、ユーザーが不要な記録を簡単に削除できるようにし、記録管理の柔軟性を高めるため。

## 実装内容
- `MoodLogsController` に `destroy` アクションを新規追加  
  - 成功時：`destroy.turbo_stream.erb` を返す  
  - 失敗時：エラー内容をモーダルに再描画
- 新規テンプレート `app/views/mood_logs/destroy.turbo_stream.erb` を作成  

## 実装結果
- 一覧ページまたはモーダルから削除操作が可能に
- ページリロードなしで対象カードがスムーズに消える

## 対応Issue
close #39 