### PR TITLE
feat: categoryモデルの作成とseedでのレコード投入

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,7 @@
+class Category < ApplicationRecord
+  has_many :habits, dependent: :nullify
+
+  validates :name, presence: true, uniqueness: true
+  validates :icon, length: { maximum: 10 }
+  validates :description, length: { maximum: 200 }, allow_blank: true
+end

--- a/db/migrate/20251112061954_create_categories.rb
+++ b/db/migrate/20251112061954_create_categories.rb
@@ -1,0 +1,11 @@
+class CreateCategories < ActiveRecord::Migration[7.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+      t.string :icon
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_29_100343) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_12_061954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.string "icon"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "feelings", force: :cascade do |t|
     t.string "name"

--- a/db/seeds/category.rb
+++ b/db/seeds/category.rb
@@ -1,0 +1,22 @@
+puts "→ Seeding categories..."
+
+categories = [
+  { name: "運動", icon: "🏃‍♂️", description: "体を動かす" },
+  { name: "勉強", icon: "📚", description: "学びを続ける" },
+  { name: "生活", icon: "🏠", description: "暮らしを整える" },
+  { name: "健康", icon: "🧘", description: "心身をケアする" },
+  { name: "食事", icon: "🍎", description: "食生活を整える" },
+  { name: "睡眠", icon: "🛏️", description: "睡眠を改善する" },
+  { name: "仕事", icon: "💼", description: "仕事に集中する" },
+  { name: "趣味", icon: "🎨", description: "好きなことを楽しむ" },
+  { name: "日常", icon: "🌱", description: "毎日を整える" }
+]
+
+categories.each do |attrs|
+  Category.find_or_create_by!(name: attrs[:name]) do |category|
+    category.icon = attrs[:icon]
+    category.description = attrs[:description]
+  end
+end
+
+puts "✅ Category seeded: #{Category.count}"


### PR DESCRIPTION
## 概要
習慣登録時にカテゴリを選択できるようにするため、  
`Category` モデルを新規作成し、初期データ（seed）を追加しました。  
これにより、習慣を分類・整理できる基盤が整いました。

---

## 実装理由
- 今後 `Habit` モデルが `Category` に紐づく設計のため  
- 習慣をカテゴリ別に表示・集計するための前準備として  
- seedによって開発・本番環境で共通カテゴリを容易に初期化するため  

---

## 実装内容
- `Category` モデルを作成  
  - カラム：`name`, `icon`, `description`
- 関連付け  
  - `has_many :habits, dependent: :nullify`
- バリデーションを追加  
  - `name` の必須・一意性  
- `db/seeds.rb` にカテゴリ初期データを追加  

---

## 対応Issue
- close #133 