### PR TITLE
【fix】バリデーションエラーによる不具合を修正

### DIFF
--- a/app/controllers/mood_logs_controller.rb
+++ b/app/controllers/mood_logs_controller.rb
@@ -75,6 +75,6 @@ class MoodLogsController < ApplicationController
   end
 
   def mood_log_params
-    params.require(:mood_log).permit(:mood_id, :feeling_id, :note, :recorded_at)
+    params.require(:mood_log).permit(:mood_id, :feeling_id, :habit_log_id, :timing, :note, :recorded_at)
   end
 end

--- a/app/models/mood_log.rb
+++ b/app/models/mood_log.rb
@@ -11,7 +11,8 @@ class MoodLog < ApplicationRecord
 
   # --- バリデーション ---
   validates :user_id, :mood_id, :recorded_at, presence: true
-  validates :timing, presence: true
+  # selfで囲うことでundefinedエラーを防止(nilを返す)
+  validates :timing, presence: true, if: -> { self[:habit_log_id].present? }
 
   # --- enum ---
   enum timing: { before: 0, after: 1 }


### PR DESCRIPTION
## 概要
通常の気分ログ登録では `habit_log` と紐づかないため、  
`habit_log_id` が未定義（undefined）となり、`timing` のバリデーションが正しく動作しない問題を修正しました。

`habit_log_id` の有無によって `timing` の必須判定が切り替わるように修正し、  
undefined を安全に扱うためのロジックを導入しました。

---

## 実装理由
- 通常の気分記録では `habit_log_id` は存在しないため、`timing` が必須であるべきではない  
- 一方で、習慣ログからの気分記録では before / after の区別が必要  
- Rails の `habit_log_id.present?` は undefined（キーなし）を正しく扱えない場合がある  
- `self[:habit_log_id]` を使うことで、nil / 空文字 / undefined をすべて安全に false 判定として扱えるようにした

---

## 対応Issue
なし
