### PR TITLE
【feat】習慣機能の追加実装（編集・削除・ホーム上でのモーダル詳細表示）

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,16 +1,25 @@
 class HabitsController < ApplicationController
-  before_action :set_habit, only: [ :edit, :update, :destroy ]
+  before_action :set_habit, only: [ :show, :edit, :update, :destroy ]
 
   def index
     # 習慣取得
-    habits = current_user.habits.includes(:category, :goals).order(:id)
+    habits = current_user.habits.includes(:category, :goal).order(:id)
     @habits = habits.limit(10)
     @habits_today = habits.for_today
     @habits_this_week = habits.for_this_week
     @habits_this_month = habits.for_this_month
   end
 
+  def show
+    if turbo_frame_request?
+      render :show, layout: false
+    else
+      redirect_to home_path
+    end
+  end
+
   def new
+    session[:habit_return_to] = request.referer
     @habit_form = HabitForm.new(user_id: current_user.id)
   end
 
@@ -19,7 +28,8 @@ class HabitsController < ApplicationController
     @habit_form = HabitForm.new(habit_params.merge(user_id: current_user.id))
 
     if @habit_form.save
-      redirect_back fallback_location: habits_path, notice: "習慣を登録しました。"
+      redirect_to(session.delete(:habit_return_to) || habits_path,
+                  notice: "習慣を登録しました。")
     else
       flash.now[:alert] = "入力内容に誤りがあります。"
       render :new, status: :unprocessable_entity
@@ -27,6 +37,7 @@ class HabitsController < ApplicationController
   end
 
   def edit
+    session[:habit_return_to] = request.referer
     @habit_form = HabitForm.from_model(@habit)
   end
 
@@ -34,7 +45,8 @@ class HabitsController < ApplicationController
     @habit_form = HabitForm.new(habit_params.merge(id: @habit.id, user_id: current_user.id))
 
     if @habit_form.update
-      redirect_back fallback_location: habits_path, notice: "習慣を更新しました。"
+      redirect_to(session.delete(:habit_return_to) || habits_path,
+                  notice: "習慣を更新しました。")
     else
       flash.now[:alert] = "入力内容に誤りがあります。"
       render :edit, status: :unprocessable_entity
@@ -43,7 +55,8 @@ class HabitsController < ApplicationController
 
   def destroy
     @habit.destroy
-    redirect_to fallback_location: habits_path, notice: "習慣を削除しました。"
+    redirect_to (request.referer.presence || habits_path),
+              notice: "習慣を削除しました。"
   end
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,7 +5,7 @@ class HomeController < ApplicationController
     # 今日のユーザーの気分登録を新しい順に取得
     @mood_logs_today = current_user.mood_logs.includes(:mood, :feeling).today.limit(10).recent
     # 習慣取得
-    habits = current_user.habits.includes(:category, :goals).order(:id)
+    habits = current_user.habits.includes(:category, :goal).order(:id)
     @habits = habits.limit(10)
     @habits_today = habits.for_today
     @habits_this_week = habits.for_this_week

--- a/app/controllers/mood_logs_controller.rb
+++ b/app/controllers/mood_logs_controller.rb
@@ -1,4 +1,6 @@
 class MoodLogsController < ApplicationController
+  before_action :set_mood_log, only: [ :show, :edit, :update, :destroy ]
+
   def create
     @mood_log = current_user.mood_logs.build(mood_log_params)
 
@@ -10,7 +12,6 @@ class MoodLogsController < ApplicationController
   end
 
   def show
-    @mood_log = current_user.mood_logs.find(params[:id])
     if turbo_frame_request?
       render :show, layout: false
     else
@@ -19,7 +20,6 @@ class MoodLogsController < ApplicationController
   end
 
   def edit
-    @mood_log = current_user.mood_logs.find(params[:id])
     if turbo_frame_request?
       render :edit, layout: false
     else
@@ -28,8 +28,6 @@ class MoodLogsController < ApplicationController
   end
 
   def update
-    @mood_log = current_user.mood_logs.find(params[:id])
-
     respond_to do |format|
       if @mood_log.update(mood_log_params)
         flash.now[:notice] = "気分記録を更新しました。"
@@ -51,8 +49,6 @@ class MoodLogsController < ApplicationController
   end
 
   def destroy
-    @mood_log = current_user.mood_logs.find(params[:id])
-
     respond_to do |format|
       if @mood_log.destroy
         flash.now[:notice] = "気分記録を削除しました。"
@@ -74,7 +70,20 @@ class MoodLogsController < ApplicationController
     end
   end
 
+  private
+
+  def set_mood_log
+    @mood_log = current_user.mood_logs.find(params[:id])
+  end
+
   def mood_log_params
-    params.require(:mood_log).permit(:mood_id, :feeling_id, :habit_log_id, :timing, :note, :recorded_at)
+    params.require(:mood_log).permit(
+      :mood_id,
+      :feeling_id,
+      :habit_log_id,
+      :timing,
+      :note,
+      :recorded_at
+    )
   end
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -2,7 +2,7 @@ class Habit < ApplicationRecord
   # --- 関連 ---
   belongs_to :user
   belongs_to :category
-  has_many :goals, dependent: :destroy
+  has_one :goal, dependent: :destroy
   has_many :habit_logs, dependent: :destroy
 
   # --- バリデーション ---
@@ -14,19 +14,19 @@ class Habit < ApplicationRecord
 
   # 今日・今週・今月の目標取得
   scope :for_today, -> {
-    joins(:goals)
+    joins(:goal)
     .merge(Goal.for_today)
     .distinct
   }
 
   scope :for_this_week, -> {
-    joins(:goals)
+    joins(:goal)
     .merge(Goal.for_this_week)
     .distinct
   }
 
   scope :for_this_month, -> {
-    joins(:goals)
+    joins(:goal)
     .merge(Goal.for_this_month)
     .distinct
   }

--- a/app/views/habits/_habit_card.html.erb
+++ b/app/views/habits/_habit_card.html.erb
@@ -19,7 +19,7 @@
 
     <!-- 詳細モーダル -->
     <%= link_to "詳細",
-          "#habit_path(habit)",
+          habit_path(habit),
           class: "btn btn-outline btn-xs",
           data: { turbo_frame: "modal" } %>
 

--- a/app/views/habits/_modal_show.html.erb
+++ b/app/views/habits/_modal_show.html.erb
@@ -1,0 +1,87 @@
+<dialog open class="modal modal-open" data-controller="modal">
+  <div class="modal-box bg-base-100">
+    <div class="space-y-6">
+
+      <!-- タイトル -->
+      <div class="flex items-center justify-between border-b border-base-300 pb-2">
+        <h3 class="font-bold text-lg text-base-content">
+          📘 習慣の詳細
+        </h3>
+
+        <% if @habit.category.present? %>
+          <span class="badge badge-outline text-xs">
+            <%= @habit.category.icon %> <%= @habit.category.name %>
+          </span>
+        <% end %>
+      </div>
+
+      <!-- 基本情報 -->
+      <div class="space-y-3 text-sm">
+        <!-- 習慣名 -->
+        <p>
+          <span class="font-semibold text-base-content/80">習慣名：</span>
+          <%= @habit.name %>
+        </p>
+
+        <!-- 説明（任意） -->
+        <% if @habit.description.present? %>
+          <div class="bg-base-200/60 rounded-lg p-3">
+            <div class="font-semibold text-base-content/80 mb-1">説明</div>
+            <div class="whitespace-pre-wrap break-words text-base-content/70"
+              ><%= @habit.description %></div>
+          </div>
+        <% end %>
+
+        <!-- 目標（任意） -->
+        <% if @habit.goal.present? %>
+          <div class="bg-base-200/60 rounded-lg p-3 space-y-1">
+            <div class="font-semibold text-base-content/80 mb-1">目標</div>
+
+            <% if @habit.goal.goal_type.present? %>
+              <p>種類：<%= @habit.goal.goal_type %></p>
+            <% end %>
+
+            <% if @habit.goal.target_value.present? %>
+              <p>目標値：<%= @habit.goal.target_value %></p>
+            <% end %>
+
+            <% if @habit.goal.start_date.present? && @habit.goal.end_date.present? %>
+              <p>期間：<%= @habit.goal.start_date %> 〜 <%= @habit.goal.end_date %></p>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+
+      <!-- アクション -->
+      <div class="modal-action flex justify-between items-center pt-4 border-t border-base-300">
+        <div class="flex gap-2">
+          <!-- 実行 -->
+          <%= link_to "実行",
+                      "#habit_logs_path(habit_id: @habit.id)",
+                      data: { turbo_method: :post },
+                      class: "btn btn-primary btn-sm" %>
+
+          <!-- 編集 -->
+          <%= link_to "編集",
+                      edit_habit_path(@habit),
+                      data: { turbo: false },
+                      class: "btn btn-outline btn-primary btn-sm" %>
+
+          <!-- 削除 -->
+          <%= link_to "削除",
+                      habit_path(@habit),
+                      data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+                      class: "btn btn-outline btn-error btn-sm" %>
+        </div>
+
+        <button type="button"
+                data-action="click->modal#close"
+                class="btn btn-sm btn-outline h-9 min-h-9 px-4">
+          閉じる
+        </button>
+      </div>
+
+    </div>
+  </div>
+</dialog>
+

--- a/app/views/habits/edit.html.erb
+++ b/app/views/habits/edit.html.erb
@@ -1,2 +1,129 @@
-<h1>Habits#edit</h1>
-<p>Find me in app/views/habits/edit.html.erb</p>
+<div class="w-full max-w-md mx-auto p-4">
+  <section class="card bg-base-100 shadow-sm" data-controller="toggle-form">
+    <div class="card-body space-y-2">
+
+      <!-- タイトル＆戻るボタン -->
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold">習慣編集</h2>
+
+        <% back = request.referer %>
+        <% back = nil if back == request.url %>
+
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          onclick="window.location = '<%= back || habits_path %>'">
+          戻る
+        </button>
+      </div>
+
+      <%= form_with model: @habit_form,
+                    url: habits_path,
+                    method: :post,
+                    local: true do |f| %>
+
+        <!-- ▼ 必須項目 -->
+        <div class="space-y-4">
+          <div class="border-l-4 border-primary/50 pl-3">
+            <p class="text-base font-semibold">必須項目</p>
+          </div>
+
+        <!-- 必須フォーム -->
+          <div class="form-control">
+            <%= f.label :name, "習慣名", class: "label-text text-sm font-semibold" %>
+            <%= f.text_field :name, class: "input input-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :category_id, "カテゴリ", class: "label-text text-sm font-semibold" %>
+            <%= f.select :category_id,
+                  options_from_collection_for_select(
+                    Category.all,
+                    :id,
+                    ->(c){ "#{c.icon} #{c.name}" },
+                    @habit_form.category_id
+                  ),
+                  { prompt: "選択してください" },
+                  class: "select select-bordered w-full" %>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :goal_type, "目標タイプ", class: "label-text text-sm font-semibold" %>
+            <%= f.select :goal_type,
+                  Goal.goal_types.keys.map { |k| [k.humanize, k] },
+                  { prompt: "選択してください" },
+                  class: "select select-bordered w-full" %>
+          </div>
+
+          <div class="form-control" data-controller="target-value">
+            <%= f.label :goal_type, "目標設定", class: "label-text text-sm font-semibold" %>
+            <%= f.select :target_type,
+                  Goal.target_types.keys.map { |k| [k.humanize, k] },
+                  { prompt: "選択してください" },
+                  class: "select select-bordered w-full",
+                  data: {
+                    action: "change->target-value#toggle",
+                    target_value_target: "typeSelect"
+                  } %>
+
+            <div data-target-value-target="targetField" class="hidden mt-3">
+              <%= f.label :target_value, "目標値（半角数字）", class: "label-text text-sm font-semibold" %>
+              <%= f.number_field :target_value, min: 1,
+                    class: "input input-bordered w-full" %>
+            </div>
+          </div>
+        </div> <!-- 必須項目ここまで -->
+
+        <!-- ▼ 任意項目（フォーム直下） -->
+        <div data-toggle-form-target="details"
+             class="hidden space-y-4">
+
+          <div class="border-b border-base-300 mt-4 mb-4"></div>
+
+          <div class="border-l-4 border-secondary pl-3">
+            <p class="text-base font-semibold">任意項目</p>
+          </div>
+
+          <div>
+            <p class="text-sm font-semibold mb-1">期間設定</p>
+            <div class="grid grid-cols-2 gap-4">
+              <div class="form-control">
+                <%= f.date_field :start_date, class: "input input-bordered w-full" %>
+              </div>
+              <div class="form-control">
+                <%= f.date_field :end_date, class: "input input-bordered w-full" %>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-control">
+            <%= f.label :description, "説明", class: "label-text text-sm font-semibold" %>
+            <%= f.text_area :description, rows: 3,
+                  class: "textarea textarea-bordered w-full" %>
+          </div>
+
+        </div>
+
+        <!-- ▼ 一番下：登録ボタン & 任意項目トグル -->
+        <div class="w-[90%] mx-auto flex gap-4 mt-6">
+
+          <button type="submit"
+                  class="btn btn-primary btn-sm flex-1 px-3 flex items-center justify-center gap-2">
+            <%= heroicon "check", options: { class: "w-4 h-4" } %>
+            登録する
+          </button>
+
+          <button type="button"
+                  class="btn btn-outline btn-sm flex-1 px-3 flex items-center justify-center gap-2"
+                  data-action="toggle-form#toggle">
+            <span data-toggle-form-target="icon">+</span>
+            <span data-toggle-form-target="label">任意項目</span>
+          </button>
+
+        </div>
+
+      <% end %>
+
+    </div>
+  </section>
+</div>

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -16,11 +16,13 @@
 
           <div>
             <p class="font-semibold"><%= habit.name %></p>
-            <% if habit.goals.active.any? %>
+
+            <% if habit.goal.present? %>
               <p class="text-sm text-base-content/70">
-                <%= habit.goals.active.first.goal_type %> 目標
+                <%= habit.goal.goal_type %> 目標
               </p>
             <% end %>
+
           </div>
 
         </div>

--- a/app/views/habits/new.html.erb
+++ b/app/views/habits/new.html.erb
@@ -2,8 +2,20 @@
   <section class="card bg-base-100 shadow-sm" data-controller="toggle-form">
     <div class="card-body space-y-2">
 
-      <!-- タイトル -->
-      <h2 class="text-lg font-semibold">習慣追加</h2>
+      <!-- タイトル＆戻るボタン -->
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold">習慣編集</h2>
+
+        <% back = request.referer %>
+        <% back = nil if back == request.url %>
+
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          onclick="window.location = '<%= back || habits_path %>'">
+          戻る
+        </button>
+      </div>
 
       <%= form_with model: @habit_form,
                     url: habits_path,
@@ -106,8 +118,8 @@
                   data-action="toggle-form#toggle">
             <span data-toggle-form-target="icon">+</span>
             <span data-toggle-form-target="label">任意項目</span>
-          </button>
 
+          </button>
         </div>
 
       <% end %>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -1,0 +1,4 @@
+<%= turbo_frame_tag 'modal' do %>
+  <%= render "habits/modal_show", habit: @habit %>
+<% end %>
+

--- a/app/views/mood_logs/_modal_show.html.erb
+++ b/app/views/mood_logs/_modal_show.html.erb
@@ -24,10 +24,9 @@
         </p>
 
         <div class="bg-base-200/60 rounded-lg p-3">
-          <p class="font-semibold text-base-content/80 mb-1">メモ</p>
-          <p class="whitespace-pre-wrap break-words text-base-content/70">
-            <%= mood_log.note.presence || "（メモはありません）" %>
-          </p>
+          <div class="font-semibold text-base-content/80 mb-1">メモ</div>
+          <div class="whitespace-pre-wrap break-words text-base-content/70"
+            ><%= mood_log.note.presence || "（メモはありません）" %></div>
         </div>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
   resources :mood_logs, only: [ :create, :show, :edit, :update, :destroy ]
 
   # habitsリソースのルーティング設定
-  resources :habits, only: [ :index, :new, :create, :edit, :update, :destroy ]
+  resources :habits
 end


### PR DESCRIPTION
## 概要
習慣（Habit）の詳細をモーダルで表示できるように実装しました。  
あわせて編集・削除の機能追加を行いました。

また、Habit に紐づく Goal は常に1つであるという仕様に変更し、関連を `has_many :goals` から `has_one :goal` に修正しました。

---

## 変更内容

### ▼ 習慣詳細モーダルの実装
- `habits#show` を Turbo によるモーダル表示へ対応  
- モーダル内に以下の情報を表示
  - 習慣名
  - カテゴリ
  - 説明
  - 目標情報（goal_type / target_value / 期間 など）

### ▼ 編集・削除機能の追加
- モーダル上から編集ページへの遷移リンクを設置  
- 削除ボタンをモーダル内にも設置

### ▼ Goal 関連の統一（has_one 化）
- `Habit` モデルを `has_one :goal` に変更  
- 関連参照の単数化（`habit.goals` → `habit.goal`）  
- `includes(:goal)` に修正  

---

## 対応 Issue
- close #50
- close #51 
