### PR TITLE
【fix】ルーティングエラーの修正

### DIFF
--- a/app/views/habit_logs/partials/_modal_form.html.erb
+++ b/app/views/habit_logs/partials/_modal_form.html.erb
@@ -96,11 +96,13 @@
       <!-- アクションボタン -->
       <div class="modal-action flex justify-between items-center pt-4 border-t border-base-300">
         <div class="flex gap-2">
-          <%= f.submit "更新", class: "btn btn-sm btn-primary h-9 min-h-9 px-4" %>
-          <%= link_to "削除",
+          <%= f.submit "#{habit_log.persisted? ? "更新" : "記録"}" , class: "btn btn-sm btn-primary h-9 min-h-9 px-4" %>
+          <% if @habit_log.persisted? %>
+            <%= link_to "削除",
                       habit_log_path(habit_log, dom_from: params[:dom_from], from: params[:from]),
                       data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
                       class: "btn btn-sm btn-outline btn-error h-9 min-h-9 px-4" %>
+          <% end %>
         </div>
 
         <button type="button"

--- a/app/views/habit_logs/partials/_modal_show.html.erb
+++ b/app/views/habit_logs/partials/_modal_show.html.erb
@@ -76,7 +76,7 @@
       </div>
     <% end %>
 
-        <!-- アクションボタン -->
+    <!-- アクションボタン -->
     <div class="modal-action flex justify-between items-center pt-4 border-t border-base-300">
       <div class="flex gap-2">
         <%= link_to "編集",

--- a/app/views/mood_logs/create.turbo_stream.erb
+++ b/app/views/mood_logs/create.turbo_stream.erb
@@ -13,6 +13,7 @@
   <%= turbo_stream.prepend "mood_logs_index" do %>
     <%= render "logs/partials/mood_log_index_card", mood_log: @mood_log %>
   <% end %>
+<% end %>
 
 <%= turbo_stream.replace "flash_area" do %>
   <%= render "shared/flash" %>

--- a/app/views/mood_logs/partials/_modal_form.html.erb
+++ b/app/views/mood_logs/partials/_modal_form.html.erb
@@ -78,11 +78,13 @@
       <!-- アクションボタン -->
       <div class="modal-action flex justify-between items-center pt-4 border-t border-base-300">
         <div class="flex gap-2">
-          <%= f.submit "更新", class: "btn btn-sm btn-primary h-9 min-h-9 px-4" %>
-          <%= link_to "削除",
-                      mood_log_path(mood_log, dom_from: params[:dom_from], from: params[:from]),
-                      data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-                      class: "btn btn-sm btn-outline btn-error h-9 min-h-9 px-4" %>
+          <%= f.submit "#{mood_log.persisted? ? "更新" : "記録"}", class: "btn btn-sm btn-primary h-9 min-h-9 px-4" %>
+          <% if mood_log.persisted? %>
+            <%= link_to "削除",
+                        mood_log_path(mood_log, dom_from: params[:dom_from], from: params[:from]),
+                        data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+                        class: "btn btn-sm btn-outline btn-error h-9 min-h-9 px-4" %>
+          <% end %>
         </div>
 
         <button type="button"


### PR DESCRIPTION
## 概要
フォーム共通化の影響で、**新規作成（id がない状態）でも id 必須リンクが描画されようとし、URL 生成時に例外が発生する不具合**が発生していました。

本PRでは、該当リンクを `persisted?` で条件分岐し、**新規作成時には表示しない**ように修正しています。

---

## 修正内容

- `_modal_form` 内の以下のリンクに `@habit_log.persisted?` を追加  
  - 削除リンク  
  - 編集／詳細など id が必要なリンク全般  
- `persisted?` により、  
  - **新規作成（id: nil）→ false → リンク非表示**  
  - **編集時（id あり）→ true → リンク表示**  
  となるため、URL 生成エラーが解消されます。

---

## 対応Issue
- 対応なし