### PR TITLE
【fix】本番とローカルのDB差分吸収

### DIFF
--- a/db/migrate/20251208114632_add_omniauth_to_users.rb
+++ b/db/migrate/20251208114632_add_omniauth_to_users.rb
@@ -1,6 +1,7 @@
 class AddOmniauthToUsers < ActiveRecord::Migration[7.2]
   def change
-    add_column :users, :provider, :string
-    add_column :users, :uid, :string
+    # すでに存在する場合はスキップ（本番・ローカル差分対策）
+    add_column :users, :provider, :string, if_not_exists: true
+    add_column :users, :uid, :string, if_not_exists: true
   end
 end

--- a/db/migrate/20251208114654_add_index_uid_and_provider_to_users.rb
+++ b/db/migrate/20251208114654_add_index_uid_and_provider_to_users.rb
@@ -1,4 +1,0 @@
-class AddIndexUidAndProviderToUsers < ActiveRecord::Migration[7.2]
-  def change
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_08_114654) do
+ActiveRecord::Schema[7.2].define(version: 2025_12_08_114632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## 概要
本番環境で `provider` カラムの重複エラー（PG::DuplicateColumn）が発生したため、  
OmniAuth 関連のマイグレーションを **再実行しても安全な形に修正**し、  ローカルと本番環境の差分を修正しました。

---

## 修正内容

- `AddOmniauthToUsers` マイグレーションに `if_not_exists: true` を追加
  - `provider` / `uid` カラムが既に存在する場合はスキップされるよう修正
- 中身が空になっていた `AddIndexUidAndProviderToUsers` マイグレーションを削除
- ローカル環境にて rollback → migrate により正常動作を確認

---

## 対応Issue
- なし