### PR TITLE
【feat】URLのIDハッシュ化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "omniauth-rails_csrf_protection", "~> 1.0.2"
 
 gem "rails-i18n"
 
+gem "hashid-rails", "~> 1.0"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,10 @@ GEM
       net-http (~> 0.5)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hashid-rails (1.4.1)
+      activerecord (>= 4.0)
+      hashids (~> 1.0)
+    hashids (1.0.6)
     hashie (5.0.0)
     heroicon (1.0.0)
       rails (>= 5.2)
@@ -397,6 +401,7 @@ DEPENDENCIES
   devise (~> 4.9)
   devise-i18n
   dotenv-rails
+  hashid-rails (~> 1.0)
   heroicon
   jbuilder
   jsbundling-rails

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -1,4 +1,5 @@
 class Habit < ApplicationRecord
+  include Hashid::Rails
   # --- 関連 ---
   belongs_to :user
   belongs_to :category

--- a/app/models/habit_log.rb
+++ b/app/models/habit_log.rb
@@ -1,4 +1,5 @@
 class HabitLog < ApplicationRecord
+  include Hashid::Rails
   # --- 関連 ---
   belongs_to :user
   belongs_to :habit

--- a/app/models/mood_log.rb
+++ b/app/models/mood_log.rb
@@ -1,4 +1,5 @@
 class MoodLog < ApplicationRecord
+  include Hashid::Rails
   # recorded_atのデフォルト値を現在時刻に設定（マイグレーションのdefaultオプションはDB側で設定されるため、validationエラーを防ぐ目的でモデル側でも設定）
   before_validation :set_default_recorded_at, on: :create
   before_validation :truncate_recorded_at_to_minute

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  include Hashid::Rails
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable,

--- a/config/initializers/hashids.rb
+++ b/config/initializers/hashids.rb
@@ -1,0 +1,21 @@
+Hashid::Rails.configure do |config|
+  # The salt to use for generating hashid. Prepended with pepper (table name).
+  config.salt = ENV.fetch("HASHID_SALT")
+
+  # The minimum length of generated hashids
+  config.min_hash_length = 6
+
+  # The alphabet to use for generating hashids
+  config.alphabet = "abcdefghijklmnopqrstuvwxyz" \
+                    "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
+                    "1234567890"
+
+  # Whether to override the `find` method
+  config.override_find = true
+
+  # Whether to override the `to_param` method
+  config.override_to_param = true
+
+  # Whether to sign hashids to prevent conflicts with regular IDs (see https://github.com/jcypret/hashid-rails/issues/30)
+  config.sign_hashids = true
+end


### PR DESCRIPTION
## 概要
URLのIDをハッシュ化しました。
これにより、ほかゆーざーのリソースIDを推測されるリスクがなくなりました。
実装にはgem**hashid-rails**を使用しました。

---

## 実装背景
Rails ではデフォルトで `id` が連番の整数として発行されます。  
そのため URL に `/users/1` / `/habits/3` のように数値 ID が露出し、  
他ユーザーのリソース ID を推測されるリスクがありました。

本番運用を見据えると、以下の理由から ID の秘匿性が必要です：

- URL から他のユーザー ID が容易に推測可能  
- 連番 ID を利用した不正アクセスの試行が可能  
- セキュリティ強化のため ID をランダム文字列にしたい  

しかし UUID/ULID で PK を変更するアプローチは  
既存テーブルの大規模変更となりコストが大きいことから、  
今回は **hashid-rails による公開ID（hashid）方式** を採用しました。

---

対応Issue
- close #191 

