### PR TITLE
【fix】トップページのみ全画面になるように修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,17 +29,19 @@
     <% end %>
 
     <main class="flex-grow">
-      <% if current_page?(unauthenticated_root_path) %>
-        <!-- LPはフル幅 -->
+
+      <% if controller_name == "static_pages" && action_name == "top" %>
+        <!-- TOPページだけフル幅 -->
         <%= yield %>
       <% else %>
-        <!-- 通常ページは今まで通り -->
+        <!-- その他（ログインページ、home、habitログ、全部） -->
         <div class="flex justify-center">
           <div class="w-full max-w-md px-4 py-6">
             <%= yield %>
           </div>
         </div>
       <% end %>
+
     </main>
 
     <% if user_signed_in? %>


### PR DESCRIPTION
## 概要
ログイン後のrootであるホーム画面が全画面になってしまう問題を修正しました。

---

## 不具合内容
`unauthenticated_root_path` であれば、全画面表示となるように場合分けしていましたが、ログイン後のページである、` authenticated_root` についても全画面表示となっていました。
これにより、ログイン後にロゴマークをクリックすると、ホーム画面のデザインが崩れる不具合が発生していました。

---

## 修正内容
トップページであれば全画面表示となるようにコードを修正することで、不具合を修正すると共に、URL直打ちでトップページに遷移した場合でも全画面表示されるように修正しました。

---

## 対応Issue
- close #197 