### PR TITLE
【fix】test時は.envのHASHID_SALTを使用するように修正

### DIFF
--- a/config/initializers/hashids.rb
+++ b/config/initializers/hashids.rb
@@ -1,6 +1,6 @@
 Hashid::Rails.configure do |config|
   # The salt to use for generating hashid. Prepended with pepper (table name).
-  config.salt = ENV.fetch("HASHID_SALT")
+  config.salt = ENV["HASHID_SALT"] || "fallback_for_test"
 
   # The minimum length of generated hashids
   config.min_hash_length = 6


### PR DESCRIPTION
## 概要
GitHub Actions（test 環境）で HASHID_SALT が設定されていないため、
initializer の `ENV.fetch` が KeyError を発生させていた。

## 修正内容
`ENV.fetch("HASHID_SALT")` を使用せず、
環境変数が未設定の際に fallback を利用する方式に変更。