### PR TITLE
【feat】ホーム画面と習慣詳細画面の再設計

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -15,6 +15,7 @@ class HabitsController < ApplicationController
   end
 
   def show
+    @progress = HabitProgress.new(habit: @habit)
     if turbo_frame_request?
       render :show, layout: false
     else

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -44,21 +44,22 @@ class Habit < ApplicationRecord
   scope :weekly, -> { joins(:goal).where(goals: { frequency: :weekly }) }
   scope :monthly, -> { joins(:goal).where(goals: { frequency: :monthly }) }
 
+  # 習慣ごとの記録を期間別に取得
+  def logs_for(range:, date: Time.zone.today)
+    case range
+    when :daily
+      habit_logs.where(started_at: date.all_day)
+    when :weekly
+      habit_logs.where(started_at: date.all_week)
+    when :monthly
+    habit_logs.where(started_at: date.all_month)
+    else
+      HabitLog.none
+    end
+  end
+
   # 実行済みの習慣か確認
   def executed_today?
   habit_logs.where(started_at: Time.zone.today.all_day).exists?
-  end
-
-  # 習慣ごとの記録を期間別に取得
-  def logs_today
-    habit_logs.where(started_at: Time.zone.today.all_day)
-  end
-
-  def logs_this_week
-    habit_logs.where(started_at: Time.zone.today.all_week)
-  end
-
-  def logs_this_month
-    habit_logs.where(started_at: Time.zone.today.all_month)
   end
 end

--- a/app/models/habit_log.rb
+++ b/app/models/habit_log.rb
@@ -37,8 +37,7 @@ class HabitLog < ApplicationRecord
   # count  → performed_value（回数）
   # time   → performed_value（分）
   def value_for_goal
-    case goal.target_type
-    when "check"
+    if goal.check_based?
       1
     else
       performed_value || 0

--- a/app/queries/habit_query.rb
+++ b/app/queries/habit_query.rb
@@ -9,6 +9,9 @@ class HabitQuery
 
   def active_base
     base.where(archived: false)
+        .joins(:goal)
+        .merge(Goal.active)
+        .distinct
   end
 
   # Goal（daily/weekly/monthly）に応じた対象習慣
@@ -16,9 +19,6 @@ class HabitQuery
 
   def habits_for(tab)
     scope = active_base
-              .joins(:goal)
-              .merge(Goal.active)
-              .distinct
 
     case tab.to_s
     when "today"

--- a/app/services/habit_progress.rb
+++ b/app/services/habit_progress.rb
@@ -1,0 +1,38 @@
+class HabitProgress
+  def initialize(habit:, date: Time.zone.today)
+    @habit = habit
+    @date  = date
+  end
+
+  def total_value
+    logs.sum(&:value_for_goal)
+  end
+
+  def target_value
+    habit.goal.amount || 1
+  end
+
+  def status
+    return :not_applicable unless target_value
+
+    rate = total_value.to_f / target_value
+
+    case rate
+    when 1.0.. then :achieved
+    when 0.5...1.0 then :almost
+    when 0.1...0.5 then :started
+    else :none
+    end
+  end
+
+  private
+
+  attr_reader :habit, :date
+
+  def logs
+    habit.logs_for(
+      range: habit.goal.frequency.to_sym,
+      date: date
+    )
+  end
+end

--- a/app/views/habits/partials/_modal_show.html.erb
+++ b/app/views/habits/partials/_modal_show.html.erb
@@ -66,24 +66,27 @@
       <% end %>
 
       <!-- 実行データ -->
-      <div class="bg-base-200/60 rounded-lg p-3 space-y-1">
+      <div class="bg-base-200/60 rounded-lg p-3 space-y-2">
+
         <div class="flex">
-          <span class="w-24 font-semibold text-base-content">今日の実行</span>
-          <span class="text-base-content/70"><%= @habit.logs_today.count %> 回</span>
+          <span class="w-24 font-semibold text-base-content">
+            今の状態
+          </span>
+          <span class="text-base-content/70">
+            <%= t("habit.progress_status.#{@progress.status}") %>
+          </span>
         </div>
 
         <div class="flex">
-          <span class="w-24 font-semibold text-base-content">今週</span>
-          <span class="text-base-content/70"><%= @habit.logs_this_week.count %> 回</span>
+          <span class="w-24 font-semibold text-base-content">
+            実行量
+          </span>
+          <span class="text-base-content/70">
+            <%= @progress.total_value %> / <%= @progress.target_value %>
+          </span>
         </div>
 
-        <div class="flex">
-          <span class="w-24 font-semibold text-base-content">累計</span>
-          <span class="text-base-content/70"><%= @habit.habit_logs.count %> 回</span>
-        </div>
       </div>
-
-    </div>
 
     <!-- アクション -->
     <div class="modal-action flex justify-between items-center pt-4 border-t border-base-300">

--- a/app/views/home/partials/_card_habit_home.html.erb
+++ b/app/views/home/partials/_card_habit_home.html.erb
@@ -13,7 +13,7 @@
         <%= habit.name %>
       </p>
       <p class="text-xs text-base-content/60 mt-1">
-        <%= "カテゴリ：#{habit.category.name}" %>
+        <%= "目標：#{habit.goal.display_goal}" %>
       </p>
     </div>
   </div>
@@ -27,23 +27,11 @@
           data: { turbo_frame: "modal" },
           class: "btn btn-outline btn-xs" %>
 
-    <% if habit.executed_today? %>
-
-      <!-- 実行済み表示 -->
-      <div class="flex items-center gap-1 text-success text-sm font-medium">
-        <%= heroicon "check-circle", options: { class: "h-4 w-4" } %>
-        実行済み
-      </div>
-
-    <% else %>
-
-      <!-- 未実行：実行ボタン（アイコンなし） -->
-      <%= link_to "実行",
-            new_habit_log_path(habit_id: habit.id, dom_from: "home", from: "new"),
-            data: { turbo_frame: "modal" },
-            class: "btn btn-primary btn-xs" %>
-
-    <% end %>
+    <!-- 未実行：実行ボタン（アイコンなし） -->
+    <%= link_to "実行",
+          new_habit_log_path(habit_id: habit.id, dom_from: "home", from: "new"),
+          data: { turbo_frame: "modal" },
+          class: "btn btn-primary btn-xs" %>
 
   </div>
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,3 +23,11 @@ ja:
       x_minutes:
         one: "1分"
         other: "%{count}分"
+
+  habit:
+    progress_status:
+      achieved: "達成済✅"
+      almost: "もう少し"
+      started: "手をつけた"
+      none: "□未着手"
+      not_applicable: "評価なし"


### PR DESCRIPTION
## 概要
ホーム画面と習慣詳細モーダルを再設計しました。  
習慣の**目標値が見やすくなり**、達成したかどうかを判断しやすくなります。

---

## 変更背景
従来のホーム画面ではカテゴリ表示が主になっており、習慣の**目標値が埋もれてしまう**課題がありました。  
本アプリでは「目標に沿って習慣を実行し、振り返る」ことが重要なため、  
目標情報を優先して表示する構成に見直しました。

---

## 実装内容
- ホーム画面  
  - 習慣カードの表示を **カテゴリ → 目標** に差し替え
- 習慣詳細モーダル  
  - 表示構成を再設計し、**目標値が一目で分かる**レイアウトに変更

---

## 対応Issue
- close #168 