### PR TITLE
【feat】Goalモデルのamountを必須にし、check_basedの時は1を自動セットするように変更

### DIFF
--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -11,9 +11,11 @@ class Goal < ApplicationRecord
   enum status: { draft: 0, active: 1, achieved: 2 }  # 目標セット
 
   # --- バリデーション ---
+  before_validation :set_amount_for_check_based
   validates :goal_unit, presence: true
   validates :frequency, presence: true
   validates :status, presence: true
+  validates :amount, presence: true
 
   # count / time の場合だけ amount が必要
   validates :amount,
@@ -90,5 +92,13 @@ class Goal < ApplicationRecord
     else
       "期間なし"
     end
+  end
+
+  private
+
+  def set_amount_for_check_based
+    return unless check_based?
+
+    self.amount = 1
   end
 end

--- a/app/services/habit_progress.rb
+++ b/app/services/habit_progress.rb
@@ -9,7 +9,7 @@ class HabitProgress
   end
 
   def target_value
-    habit.goal.amount || 1
+    habit.goal.amount
   end
 
   def status


### PR DESCRIPTION
## 概要
check_based の目標（goal）を作成・更新する際に、amount が常に 1 になるように修正しました。

チェック型の習慣は「達成 / 未達成」のみを扱うため、amount をユーザー入力に依存せず、
モデル側で自動補完する仕様にしています。

---

## 変更内容
- Goal モデルに `before_validation` を追加
- target_type が `check_based` の場合、amount に 1 を自動セット
- habit_progress.rb の条件分岐を削除
---

## 対応Issue
- close #200 