### PR TITLE
【fix】habit_logのバリデーションに習慣の有効期間内であることを追加

### DIFF
--- a/app/forms/habit_log_form.rb
+++ b/app/forms/habit_log_form.rb
@@ -28,6 +28,7 @@ class HabitLogForm
   validates :performed_value,
             numericality: { greater_than_or_equal_to: 0 },
             allow_nil: true
+  validate :within_habit_active_range
 
   # new/edit データ構成
   def initialize(user:, habit: nil, habit_log: nil, attributes: {})
@@ -99,5 +100,25 @@ class HabitLogForm
       "#{timing}_feeling_id": log.feeling_id,
       "#{timing}_note": log.note
     }
+  end
+
+  # 時刻範囲がhabitの期間指定に収まっているか
+  def within_habit_active_range
+    return if habit.blank?
+    return if habit.goal.blank?
+    return if started_at.blank? && ended_at.blank?
+
+    active_start = habit.goal.start_date
+    active_end   = habit.goal.end_date
+
+    if started_at.present? &&
+      !started_at.between?(active_start, active_end)
+      errors.add(:started_at, "は習慣が有効な期間内で記録してください")
+    end
+
+    if ended_at.present? &&
+      !ended_at.between?(active_start, active_end)
+      errors.add(:ended_at, "は習慣が有効な期間内で記録してください")
+    end
   end
 end


### PR DESCRIPTION
## 概要
習慣ログが、習慣の有効期間外（開始前・終了後）でも記録できてしまう不具合を修正しました。

---

## 背景
HabitLog の保存時に、started_at / ended_at が Habit に紐づく Goal の有効期間を超えていても
記録できてしまう状態でした。
これはビジネスルール上、意図しない挙動のため制限を追加しています。

---

## 修正内容
- HabitLogForm に `within_habit_active_range` バリデーションを追加
- started_at / ended_at が Habit（Goal）の有効な日時範囲内に収まっているかを検証
- 範囲外の場合は該当フィールドにエラーを付与

---

## 対応Issue
- close #201 