### PR TITLE
【fix】習慣記録フォームの時刻空欄時の不具合修正、初期入力変更

### DIFF
--- a/app/forms/habit_log_form.rb
+++ b/app/forms/habit_log_form.rb
@@ -69,10 +69,14 @@ class HabitLogForm
   end
 
   def new_attributes
+    default_mood = 3
     {
       habit_id: habit.id,
       goal_id: habit.goal&.id,
-      started_at: Time.current
+      started_at: Time.current,
+      before_mood_id: default_mood,
+      ended_at: Time.current,
+      after_mood_id: default_mood
     }
   end
 


### PR DESCRIPTION
## 概要
習慣記録フォームの時刻が空欄時に記録ボタンを押すと、エラーとなり操作不能となる不具合を修正しました。
主要な項目欄に初期値を入力しておくことでユーザーの負担を軽減しました。

---

## 修正内容
時刻が空欄であるときにreturnを返す記述がなかったことで between?構文に time, nil が渡されてしまうことでエラーが発生していました。空欄であるときにreturnする記述を追記しました。

