### PR TITLE
【fix】moodモデルのスコアを1から始まるように修正

### DIFF
--- a/db/seeds/moods.rb
+++ b/db/seeds/moods.rb
@@ -1,18 +1,18 @@
-puts "→ Seeding moods..."
+puts "→ Reseeding moods..."
+
+MoodLog.delete_all
+Mood.delete_all
 
 presets = [
-  { score: 0, label: "very_bad",  color: "bg-blue-300" },
-  { score: 1, label: "bad",       color: "bg-sky-300" },
-  { score: 2, label: "neutral",   color: "bg-yellow-300" },
-  { score: 3, label: "good",      color: "bg-orange-300" },
-  { score: 4, label: "very_good", color: "bg-pink-300" }
+  { score: 1, label: "very_bad",  color: "bg-blue-300" },
+  { score: 2, label: "bad",       color: "bg-sky-300" },
+  { score: 3, label: "neutral",   color: "bg-yellow-300" },
+  { score: 4, label: "good",      color: "bg-orange-300" },
+  { score: 5, label: "very_good", color: "bg-pink-300" }
 ]
 
 presets.each do |attrs|
-  Mood.find_or_create_by!(score: attrs[:score]) do |mood|
-    mood.label = attrs[:label]
-    mood.color = attrs[:color]
-  end
+  Mood.create!(attrs)
 end
 
-puts "✅ Moods seeded: #{Mood.count}"
+puts "✅ Moods reseeded: #{Mood.count}"


### PR DESCRIPTION
## 概要
moodモデルのスコアが0基準であったため、平均値を求める際に期待した値とズレが発生していました。
seedを使用することでscoreを1基準にして投入することで不具合を修正します。
reseed後はレコードの再生成を防ぐためにseedを編集します。

---

## 対応Issue
- close #215 