### PR TITLE
【feat】reactionsの気分グラフ集計メソッドを実装

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -9,8 +9,13 @@ class ReactionsController < ApplicationController
                   .for_date(@date)
                   .recent
 
-    @mood_graph_values =
-      @mood_logs.pluck(:recorded_at, :score)
+    logs_scope =
+      current_user.mood_logs
+                  .includes(:mood)
+                  .for_date(@date)
+
+    aggregation = TimeSeriesAggregation.new(logs_scope).call
+    @mood_graph_values = aggregation[:points]
 
     @habit_logs =
       current_user.habit_logs

--- a/app/javascript/controllers/mood_graph_controller.js
+++ b/app/javascript/controllers/mood_graph_controller.js
@@ -27,10 +27,15 @@ export default class extends Controller {
     const accent      = themeColor("--color-accent")
 
     // 時系列データ
-    const data = this.valuesValue.map(v => ({
-      x: new Date(v[0]),
-      y: v[1]
-    }))
+    const data = this.valuesValue
+      .map((v) => {
+        const time = v?.time ?? v?.[0]
+        const value = v?.value ?? v?.[1]
+        if (time == null || value == null) return null
+
+        return { x: new Date(time), y: value }
+      })
+      .filter(Boolean)
 
     this.chart = new Chart(canvas, {
       type: "line",

--- a/app/services/time_series_aggregation.rb
+++ b/app/services/time_series_aggregation.rb
@@ -1,0 +1,81 @@
+class TimeSeriesAggregation
+  def initialize(scope)
+    @scope = scope
+  end
+
+  # 返り値: { time => average_score, ... }
+  def call
+    from = @scope.minimum(:recorded_at)
+    to   = @scope.maximum(:recorded_at)
+
+    return { unit: :hour, points: [] } if from.nil? || to.nil?
+
+    @from = from
+    unit = decide_unit(from, to)
+    data = aggregate(unit)
+
+    { unit: unit, points: format_points(data) }
+  end
+
+  private
+
+  # 集約単位を決定
+  def decide_unit(from, to)
+    diff = to - from
+
+    case diff
+    when ..12.hours then :quarter_hour
+    when ..1.days   then :half_hour
+    when ..7.days   then :hour
+    when ..30.days  then :day
+    when ..90.days  then :three_days
+    when ..180.days then :week
+    else                 :month
+    end
+  end
+
+  # 集約単位ごとにまとめ、気分の平均化
+  # 返り値: { time => average_score, ... }
+  def aggregate(unit)
+    case unit
+    when :quarter_hour
+      @scope.group_by_minute(:recorded_at, n: 15).average("moods.score")
+    when :half_hour
+      @scope.group_by_minute(:recorded_at, n: 30).average("moods.score")
+    when :hour
+      @scope.group_by_hour(:recorded_at).average("moods.score")
+    when :day
+      @scope.group_by_day(:recorded_at).average("moods.score")
+    when :week
+      @scope.group_by_week(:recorded_at).average("moods.score")
+    when :month
+      @scope.group_by_month(:recorded_at).average("moods.score")
+    when :three_days
+      aggregate_three_days
+    end
+  end
+
+  # 3日ごとにグルーピングして平均を計算
+  def aggregate_three_days
+    logs = @scope.to_a
+    return {} if logs.empty?
+
+    from_date = @from.to_date
+
+    # bucketはグルーピングの代表時刻に変換（group_byのキー）
+    # time: bucket, value: average_score
+    logs
+      .group_by { |log| ((log.recorded_at.to_date - from_date).to_i / 3) }
+      .transform_keys { |bucket| (from_date + bucket * 3).to_time }
+      .transform_values do |bucket_logs|
+        bucket_logs.sum { |log| log.mood.score } / bucket_logs.size.to_f
+      end
+  end
+
+  # グラフ描画用のハッシュ配列に変換
+  def format_points(data)
+    data.map do |time, value|
+      { time: time, value: value }
+    end.sort_by { |p| p[:time] }
+  end
+end


### PR DESCRIPTION
## 概要
Reactions画面で気分グラフの表示崩れを防ぐために、気分ログを時系列に集計する TimeSeriesAggregation を実装しました。
logの時刻範囲に合わせて、集約範囲を変更することで、プロット過多による表示崩れを防いでいます。
あわせてログ0件などの境界ケースでも落ちないように調整しました。

---

##実装内容
- TimeSeriesAggregation を新規実装し、記録期間に応じて集計単位（15分/30分/時/日/週/月/3日）を自動選択して平均値を算出
集計結果を [{ time:, value: }] の points に整形し、時間順にソートして返却
- Reactions画面で集計対象の気分ログを取得し、points を @mood_graph_values として data-* 属性にJSONで埋め込み
- Stimulus（mood_graph_controller.js）で @mood_graph_values を読み取る際に、ハッシュ形式と配列形式に対応
- ログ0件で from/to=nil になる場合は空データを返すようにしてエラー回避

---

## 対応Issue
- close #229 