### PR TITLE
【fix】habit show の進捗表示を日付指定対応に修正（Date.current 統一）

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -17,7 +17,14 @@ class HabitsController < ApplicationController
   end
 
   def show
-    @progress = HabitProgress.new(habit: @habit)
+    @date =
+      begin
+        params[:date].present? ? Date.parse(params[:date]) : Date.current
+      rescue ArgumentError
+        Date.current
+      end
+
+    @progress = HabitProgress.new(habit: @habit, date: @date)
     if turbo_frame_request?
       render :show, layout: false
     else

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -62,6 +62,6 @@ class Habit < ApplicationRecord
 
   # 実行済みの行動か確認
   def executed_today?
-  habit_logs.where(started_at: Time.zone.today.all_day).exists?
+  habit_logs.where(started_at: Date.current.all_day).exists?
   end
 end

--- a/app/models/habit_log.rb
+++ b/app/models/habit_log.rb
@@ -15,7 +15,7 @@ class HabitLog < ApplicationRecord
   validates :performed_value, presence: true
 
   # --- スコープ ---
-  scope :for_today, -> { where(started_at: Time.zone.today.all_day) }
+  scope :for_today, -> { where(started_at: Date.current.all_day) }
   scope :for_date, ->(date) { where(started_at: date.all_day) }
   scope :for_habit, ->(habit_id) { where(habit_id: habit_id) }
   scope :for_goal, ->(goal_id) { where(goal_id: goal_id) }

--- a/app/models/mood_log.rb
+++ b/app/models/mood_log.rb
@@ -19,7 +19,7 @@ class MoodLog < ApplicationRecord
   enum timing: { before: 0, after: 1 }
 
   # --- スコープ ---
-  scope :for_today, -> { where(recorded_at: Time.zone.today.all_day) } # Time.currentではall_dayが使用できないため、Time.zone.todayを採用
+  scope :for_today, -> { where(recorded_at: Date.current.all_day) }
   scope :for_date, ->(date) { where(recorded_at: date.all_day) }
   scope :recent, -> { order(recorded_at: :desc) }
 

--- a/app/services/habit_progress.rb
+++ b/app/services/habit_progress.rb
@@ -1,7 +1,7 @@
 class HabitProgress
   attr_reader :habit, :frequency, :date
 
-  def initialize(habit:, date: Time.zone.today, frequency: :daily)
+  def initialize(habit:, date: Date.current, frequency: :daily)
     @habit = habit
     @date  = date
     @frequency = frequency

--- a/app/views/habits/partials/_modal_show.html.erb
+++ b/app/views/habits/partials/_modal_show.html.erb
@@ -67,10 +67,13 @@
 
       <!-- 実行データ -->
       <div class="bg-base-200/60 rounded-lg p-3 space-y-2">
+        <div class="font-semibold text-base-content">
+          <%= l(@date, format: :long) %>（<%= %w(日 月 火 水 木 金 土)[@date.wday] %>） の進捗
+        </div>
 
         <div class="flex">
           <span class="w-24 font-semibold text-base-content">
-            今の状態
+            進捗状態
           </span>
           <span class="text-base-content/70">
             <%= t("habit.progress_status.#{@progress.status}") %>

--- a/app/views/reactions/partials/_habit_summary_habits.html.erb
+++ b/app/views/reactions/partials/_habit_summary_habits.html.erb
@@ -7,7 +7,7 @@
 <div class="grid grid-cols-1 gap-2 pt-2">
   <% progresses.each do |progress| %>
 
-    <%= link_to habit_path(progress.habit),
+    <%= link_to habit_path(progress.habit, date: @date),
                 data: { turbo_frame: "modal" },
                 class: "block" do %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
   resources :reactions, only: [ :show ], param: :date
   # reaction_today_pathで今日の振り返りに遷移
   get "reaction", to: redirect { |_, req|
-    date = Time.zone.today.to_s
+    date = Date.current.to_s
     "/reactions/#{date}"
   }, as: :reaction_today
 


### PR DESCRIPTION
## 概要
振り返りページから習慣詳細モーダルを開いた際、
選択した日付に関係なく「今日の進捗」が表示されてしまう問題がありました。

原因は、habit#show が日付パラメータを受け取らず、
常に当日（today）を基準に進捗を生成していたためです。

本PRでは、以下の修正で UI とデータの整合性を改善しています。
- 日付を基準に進捗を表示する設計に変更
- 不正な日付や未指定時でも安全に動作するようフォールバックを追加

---

## 修正内容
- 日付取得を `Date.current` に統一
  - 日付を扱う箇所をすべて `Date.current` 基準に統一
  - `Time.zone.today` を使用しない設計に変更
- `habit#show` で `params[:date]` を受け取れる設計に変更
  - params[:date] がある場合はその日付の進捗を表示
  - 未指定または不正な値の場合は Date.current を使用
  - params 由来の例外による 500 エラーを防止
 - 振り返りページの詳細リンクに params[:date] を付与
   - 振り返り画面からは選択中の日付を渡す
   - 他画面からは date を渡さず、show 側で Date.current を採用

---

## 対応Issue
- close #227 