### PR TITLE
【fix】Reactions#show の表示用データ構築を ViewModel（Context）に切り出し、show/share で再利用できる構造へリファクタリング

### DIFF
--- a/app/controllers/reactions_controller.rb
+++ b/app/controllers/reactions_controller.rb
@@ -1,62 +1,8 @@
 class ReactionsController < ApplicationController
   def show
     @date = parse_date(params[:date]) || Date.current
-
-    # --- その日のログ ---
-    @mood_logs =
-      current_user.mood_logs
-                  .includes(:mood, :feeling)
-                  .for_date(@date)
-                  .recent
-
-    logs_scope =
-      current_user.mood_logs
-                  .includes(:mood)
-                  .for_date(@date)
-
-    aggregation = TimeSeriesAggregation.new(logs_scope).call
-    @mood_graph_values = aggregation[:points]
-
-    @habit_logs =
-      current_user.habit_logs
-                  .includes(:habit, mood_logs: :mood)
-                  .for_date(@date)
-                  .recent
-
-    @habits =
-      current_user.habits
-                  .includes(:goal, :category)
-                  .kept
-                  .with_active_goal
-                  .with_effective_goal_on(@date)
-
-    # --- 平均気分 ---
-    @avg_mood =
-      @mood_logs
-        .joins(:mood)
-        .average("moods.score")
-        &.to_f
-
-    # --- 行動集計（結果） ---
-    frequency = %i[daily weekly monthly]
-
-    @summaries =
-      frequency.index_with do |frequency|
-        # Habit.noneを返すことでActiveRecord::Relationとなる
-        frequency_habits = @habits.public_send(frequency) || Habit.none
-        progresses =
-          frequency_habits.map do |habit|
-            HabitProgress.new(
-              habit: habit,
-              date: @date,
-              frequency: frequency
-            )
-          end
-
-        HabitProgressSummary.new(progresses, @date, frequency)
-      end
+    @context = ReactionContext.new(user: current_user, date: @date)
   end
-
 
   private
 

--- a/app/models/reaction_context.rb
+++ b/app/models/reaction_context.rb
@@ -1,0 +1,89 @@
+class ReactionContext
+  attr_reader :date,
+              :mood_logs,
+              :habit_logs,
+              :habits,
+              :avg_mood,
+              :mood_graph_values,
+              :summaries
+
+  def initialize(user:, date:)
+    @user = user
+    @date = date
+    build
+  end
+
+  private
+
+  def build
+    build_mood_logs
+    build_mood_graph
+    build_habit_logs
+    build_habits
+    build_avg_mood
+    build_summaries
+  end
+
+  def build_mood_logs
+    @mood_logs =
+      @user.mood_logs
+           .includes(:mood, :feeling)
+           .for_date(@date)
+           .recent
+  end
+
+  def build_mood_graph
+    logs_scope =
+      @user.mood_logs
+           .includes(:mood)
+           .for_date(@date)
+
+    aggregation = TimeSeriesAggregation.new(logs_scope).call
+    @mood_graph_values = aggregation[:points]
+  end
+
+  def build_habit_logs
+    @habit_logs =
+      @user.habit_logs
+           .includes(:habit, mood_logs: :mood)
+           .for_date(@date)
+           .recent
+  end
+
+  def build_habits
+    @habits =
+      @user.habits
+           .includes(:goal, :category)
+           .kept
+           .with_active_goal
+           .with_effective_goal_on(@date)
+  end
+
+  def build_avg_mood
+    @avg_mood =
+      @mood_logs
+        .joins(:mood)
+        .average("moods.score")
+        &.to_f
+  end
+
+  def build_summaries
+    frequency = %i[daily weekly monthly]
+
+    @summaries =
+      frequency.index_with do |frequency|
+        frequency_habits = @habits.public_send(frequency) || Habit.none
+
+        progresses =
+          frequency_habits.map do |habit|
+            HabitProgress.new(
+              habit: habit,
+              date: @date,
+              frequency: frequency
+            )
+          end
+
+        HabitProgressSummary.new(progresses, @date, frequency)
+      end
+  end
+end

--- a/app/views/reactions/show.html.erb
+++ b/app/views/reactions/show.html.erb
@@ -3,21 +3,21 @@
   <%= render "reactions/partials/header", date: @date %>
 
   <%= render "reactions/partials/mood_summary",
-             avg_mood: @avg_mood %>
+             avg_mood: @context.avg_mood %>
 
   <div class="card bg-base-100 shadow-sm" data-controller="swiper">
     <div class="card-body p-4 space-y-4">
 
       <%= render "reactions/partials/tabs",
-                 summaries: @summaries %>
+                 summaries: @context.summaries %>
 
       <%= render "reactions/partials/swiper",
-                 summaries: @summaries %>
+                 summaries: @context.summaries %>
 
     </div>
   </div>
 
   <%= render "reactions/partials/mood_timeline",
-             mood_logs: @mood_logs %>
+             mood_logs: @context.mood_logs %>
 
 </div>


### PR DESCRIPTION
## 概要
Xシェア（share）画面の追加に向けて、`ReactionsController#show` に集約されていた「日付ごとの表示用データ取得・集計ロジック」を `ReactionContext`（ViewModel）に切り出しました。  
これにより、`show` と `share` で同一のデータ準備を再利用でき、コントローラの責務を「画面に必要な文脈を組み立てる」ことに寄せられます。

## 実装内容
- `ReactionContext`（ViewModel/Context）を追加し、日付単位の表示用データを集約
  - `date`
  - `mood_logs`
  - `mood_graph_values`
  - `habit_logs`
  - `habits`
  - `avg_mood`
  - `summaries`
- `ReactionsController#show`（および `share` 追加予定）で `ReactionContext` を生成するように変更
- view は `@context.xxx` 参照に置換（または過渡期対応として `@date = @context.date` 等の委譲）

## 対応Issue
- close #247