### PR TITLE
【feat】利用規約ページの実装

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,5 @@
 class StaticPagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: [ :top ]
+  skip_before_action :authenticate_user!, only: [ :top, :terms ]
   def top; end
+  def terms; end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -58,11 +58,16 @@
             </li>
 
             <li class="border-t my-1"></li>
-            <li><%= link_to t("navigation.terms"), "#", class: "text-xs" %></li>
+            <li><%= link_to t("navigation.terms"), terms_path, class: "text-xs" %></li>
             <li><%= link_to t("navigation.privacy_policy"), "#", class: "text-xs" %></li>
           <% else %>
+            <li><%= link_to t("navigation.top"), top_path %></li>
             <li><%= link_to t("actions.login"), new_user_session_path %></li>
             <li><%= link_to t("actions.sign_up"), new_user_registration_path %></li>
+
+            <li class="border-t my-1"></li>
+            <li><%= link_to t("navigation.terms"), terms_path, class: "text-xs" %></li>
+            <li><%= link_to t("navigation.privacy_policy"), "#", class: "text-xs" %></li>
           <% end %>
         </ul>
       </div>

--- a/app/views/static_pages/terms.html.erb
+++ b/app/views/static_pages/terms.html.erb
@@ -1,0 +1,213 @@
+<main class="min-h-screen bg-base-100">
+  <!-- Hero -->
+  <section class="border-b border-base-200/70">
+    <div class="mx-auto w-full px-4 py-8">
+      <div class="flex items-start gap-4">
+        <div class="mt-1 inline-flex h-10 w-10 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <span class="text-lg">🌿</span>
+        </div>
+
+        <div class="flex-1">
+          <div class="flex items-center justify-between mb-4">
+            <h1 class="text-xl font-semibold tracking-tight text-base-content">
+              利用規約
+            </h1>
+
+            <% back = request.referer %>
+            <% back = nil if back == request.url %>
+
+            <button
+              type="button"
+              class="btn btn-outline btn-xs flex items-center gap-1"
+              onclick="window.location = '<%= back || habits_path %>'">
+              <%= heroicon "arrow-uturn-left", variant: :outline, options: { class: "w-4 h-4" } %>
+              戻る
+            </button>
+          </div>
+
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <span class="badge badge-primary badge-outline">kokolog</span>
+            <span class="badge badge-ghost">最終更新日：2026年1月1日</span>
+          </div>
+
+          <p class="mt-4 text-sm leading-relaxed text-base-content/70">
+            「kokolog」（以下、「本サービス」といいます。）は、ユーザーの皆様に快適かつ安全にご利用いただくため、以下の利用規約（以下、「本規約」といいます。）を定めます。
+            本サービスをご利用いただいた場合、本規約に同意したものとみなします。
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Content -->
+  <section>
+    <div class="mx-auto max-w-3xl px-4 py-8 sm:py-10">
+      <!-- 目次 -->
+      <div class="rounded-xl border border-base-200 bg-base-100 p-4">
+        <div class="flex items-center justify-between gap-3">
+          <h2 class="text-sm font-semibold text-base-content">目次</h2>
+          <span class="text-xs text-base-content/50">※タップで移動</span>
+        </div>
+
+        <div class="text-xs mt-4 grid gap-2 sm:grid-cols-2">
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-1">1. 適用</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-2">2. 禁止事項</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-3">3. ログイン情報の管理</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-4">4. 投稿コンテンツについて</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-5">5. サービスの変更・終了</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-6">6. 免責事項</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-7">7. 利用停止</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-8">8. 規約の変更</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-9">9. お問い合わせ</a>
+          <a class="btn btn-ghost btn-sm h-10 justify-start items-center text-base-content hover:text-primary rounded-xl" href="#sec-10">10. 準拠法・管轄</a>
+        </div>
+      </div>
+
+      <!-- 規約本文 -->
+      <article class="mt-8 space-y-8">
+        <!-- 共通スタイル: 見出し/本文 -->
+        <!-- Section 1 -->
+        <section id="sec-1" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">1. 適用</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            本規約は、本サービスの利用に関する一切の関係に適用されるものとします。
+          </p>
+        </section>
+
+        <!-- Section 2 -->
+        <section id="sec-2" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">2. 禁止事項</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            ユーザーは、以下の行為を行ってはなりません。
+          </p>
+
+          <ul class="mt-4 space-y-2 text-sm text-base-content/75">
+            <li class="flex gap-2">
+              <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-primary/70"></span>
+              法令または公序良俗に違反する行為
+            </li>
+            <li class="flex gap-2">
+              <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-primary/70"></span>
+              他のユーザーまたは第三者の権利を侵害する行為
+            </li>
+            <li class="flex gap-2">
+              <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-primary/70"></span>
+              不正な目的で本サービスを利用する行為
+            </li>
+            <li class="flex gap-2">
+              <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-primary/70"></span>
+              本サービスの運営を妨害する行為
+            </li>
+            <li class="flex gap-2">
+              <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-primary/70"></span>
+              本規約に違反する行為
+            </li>
+            <li class="flex gap-2">
+              <span class="mt-1 inline-block h-1.5 w-1.5 rounded-full bg-primary/70"></span>
+              その他、本サービス運営者が不適切と判断する行為
+            </li>
+          </ul>
+
+          <div class="mt-5 rounded-xl bg-base-200/50 p-4">
+            <p class="text-sm leading-relaxed text-base-content/70">
+              本サービス運営者は、ユーザーが上記に該当すると判断した場合、事前の通知なく、本サービスの全部もしくは一部の利用を制限、または登録を抹消することができます。
+              これによりユーザーに生じた損害について、本サービス運営者は一切の責任を負いません。
+            </p>
+          </div>
+        </section>
+
+        <!-- Section 3 -->
+        <section id="sec-3" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">3. ログイン情報の管理</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            ユーザーは、自己の責任において、本サービスのログイン情報を適切に管理するものとします。
+          </p>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            ログイン情報が第三者によって使用されたことにより生じた損害について、本サービス運営者は、故意または重大な過失がある場合を除き、一切の責任を負いません。
+          </p>
+        </section>
+
+        <!-- Section 4 -->
+        <section id="sec-4" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">4. 投稿コンテンツについて</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            ユーザーが本サービスに投稿するコンテンツ（テキスト等）について、ユーザーは自身が投稿する権利を有していることを保証するものとします。
+          </p>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            本サービス運営者は、本サービスの運営・改善の目的の範囲内で、当該コンテンツを利用できるものとします。
+          </p>
+        </section>
+
+        <!-- Section 5 -->
+        <section id="sec-5" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">5. サービスの変更・終了</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            本サービス運営者は、ユーザーへの事前の通知なく、本サービスの内容を変更、追加、または停止・終了することがあります。
+          </p>
+        </section>
+
+        <!-- Section 6 -->
+        <section id="sec-6" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">6. 免責事項</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            本サービス運営者は、本サービスの内容について、その正確性、完全性、有用性等を保証するものではありません。
+          </p>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            ユーザーが本サービスを利用したこと、または利用できなかったことにより生じた損害について、本サービス運営者は一切の責任を負いません。
+          </p>
+
+          <div class="mt-5 rounded-xl border border-base-200 bg-base-100 p-4">
+            <p class="text-xs leading-relaxed text-base-content/55">
+              ※本サービスは、ユーザーの記録・振り返りを支援する目的で提供されるものであり、医療的・専門的助言を行うものではありません。
+              必要に応じて専門家へご相談ください。
+            </p>
+          </div>
+        </section>
+
+        <!-- Section 7 -->
+        <section id="sec-7" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">7. 利用停止</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            ユーザーは、本サービスの利用をいつでも停止することができます。
+          </p>
+        </section>
+
+        <!-- Section 8 -->
+        <section id="sec-8" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">8. 規約の変更</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            本サービス運営者は、本規約を変更することがあります。変更後の規約は、本サービス上に掲示した時点で効力を生じるものとします。
+          </p>
+        </section>
+
+        <!-- Section 9 -->
+        <section id="sec-9" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">9. お問い合わせ</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            本規約に関するお問い合わせは、本サービス内のお問い合わせフォームよりご連絡ください。
+          </p>
+
+          <!-- 任意：リンクがある場合だけ使う -->
+          <div class="mt-4">
+            <a class="btn btn-primary btn-sm rounded-xl" href="/contact">
+              お問い合わせフォームへ
+            </a>
+          </div>
+        </section>
+
+        <!-- Section 10 -->
+        <section id="sec-10" class="scroll-mt-24 rounded-2xl border border-base-200 bg-base-100 p-6 shadow-sm">
+          <h2 class="text-lg font-bold text-base-content">10. 準拠法・管轄</h2>
+          <p class="mt-3 text-sm leading-relaxed text-base-content/70">
+            本規約の解釈には日本法を準拠法とし、本サービスに関して紛争が生じた場合には、日本国内の裁判所を専属的合意管轄とします。
+          </p>
+        </section>
+
+        <!-- Footer note -->
+        <div class="pt-2 text-center">
+          <a href="#top" class="link link-hover text-sm text-base-content/50">ページ上部へ戻る</a>
+        </div>
+      </article>
+    </div>
+  </section>
+</main>

--- a/config/locales/navigation.en.yml
+++ b/config/locales/navigation.en.yml
@@ -1,5 +1,6 @@
 en:
   navigation:
+    top: "Top"
     home: "Home"
     habits: "Habits"
     calendar: "Calendar"

--- a/config/locales/navigation.ja.yml
+++ b/config/locales/navigation.ja.yml
@@ -1,5 +1,6 @@
 ja:
   navigation:
+    top: "トップ"
     home: "ホーム"
     habits: "行動"
     calendar: "カレンダー"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,14 +21,14 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
-  # Defines the root path route ("/")
   root "static_pages#top"
 
-  # ログイン後のホーム画面
+  get "/top", to: "static_pages#top"
+
+  get "/terms", to: "static_pages#terms"
+
   get "home", to: "home#index"
 
-  # mood_logsリソースのルーティング設定
-  # indexは別途logsコントローラーで定義予定
   resources :mood_logs, only: [ :new, :create, :show, :edit, :update, :destroy ]
 
   # habitsリソースのルーティング設定
@@ -48,11 +48,11 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :calendars, only: [ :index, :show ], param: :date
+
   # reaction_today_pathで今日の振り返りに遷移
   get "reaction", to: redirect { |_, _|
     date = Date.current.to_s
     "/reactions/#{date}"
   }, as: :reaction_today
-
-  resources :calendars, only: [ :index, :show ], param: :date
 end


### PR DESCRIPTION
## 概要

利用規約ページを新規作成しました。
現行のアプリ全体レイアウト（`max-w-md` 前提）に合わせ、スマホでの閲覧を主軸にした構成・スタイルに調整しています。

---

## 実装内容
- `/terms` ページを追加（StaticPages）
- 利用規約の文面作成
- 目次付きの構成を採用し、各セクションへアンカーリンクで移動可能に

---

## 対応Issue
- close #68 