### PR TITLE
【fix】カレンダーの詳細モーダルUIを修正

### DIFF
--- a/app/views/calendars/partials/_modal_show.html.erb
+++ b/app/views/calendars/partials/_modal_show.html.erb
@@ -17,30 +17,34 @@
     </div>
 
     <!-- ▼ 本文（スクロール可能領域） -->
-    <div class="space-y-6 mt-4 pb-16">
-      <div class="space-y-3">
+    <div class="mt-4 mb-6">
+      <div class="space-y-2">
 
         <h3 class="text-lg font-semibold mb-2">行動ログ</h3>
-        <% if @habit_logs.any? %>
-          <div class="space-y-3">
-            <% @habit_logs.each do |log| %>
-              <%= render "calendars/partials/card_habit_log_logs", habit_log: log %>
-            <% end %>
-          </div>
-        <% else %>
-          <p class="text-base-content/60">この日の行動ログはありません</p>
-        <% end %>
+        <div class="h-68 overflow-y-auto">
+          <% if @habit_logs.any? %>
+            <div class="space-y-3">
+              <% @habit_logs.each do |log| %>
+                <%= render "calendars/partials/card_habit_log_logs", habit_log: log %>
+              <% end %>
+            </div>
+          <% else %>
+            <p class="text-base-content/60">この日の行動ログはありません</p>
+          <% end %>
+        </div>
 
-        <h3 class="text-lg font-semibold mt-6 mb-2">気分ログ</h3>
-        <% if @mood_logs.any? %>
-          <div class="space-y-3">
-            <% @mood_logs.each do |log| %>
-              <%= render "calendars/partials/card_mood_log_logs", mood_log: log %>
-            <% end %>
-          </div>
-        <% else %>
-          <p class="text-base-content/60">この日の気分ログはありません</p>
-        <% end %>
+        <h3 class="text-lg font-semibold mt-4 mb-2">気分ログ</h3>
+        <div class="h-68 overflow-y-auto">
+          <% if @mood_logs.any? %>
+            <div class="space-y-3">
+              <% @mood_logs.each do |log| %>
+                <%= render "calendars/partials/card_mood_log_logs", mood_log: log %>
+              <% end %>
+            </div>
+          <% else %>
+            <p class="text-base-content/60">この日の気分ログはありません</p>
+          <% end %>
+        </div>
 
       </div>
     </div>
@@ -49,21 +53,20 @@
 <% end %>
 
 <!-- ▼ モーダル固定閉じるボタン（frame の外）-->
-<div class="fixed bottom-4 left-4 right-4 z-50">
-  <div class="flex justify-between items-center max-w-md mx-auto">
+<div class="flex justify-between items-center max-w-md mx-auto">
 
-    <!-- 左：閉じる -->
-    <button type="button"
-            data-action="click->modal#close"
-            class="btn btn-sm btn-outline h-9 min-h-9 px-4 shadow-lg">
-      閉じる
-    </button>
+  <!-- 左：閉じる -->
+  <button type="button"
+          data-action="click->modal#close"
+          class="btn btn-sm btn-outline h-9 min-h-9 px-4 shadow-lg">
+    閉じる
+  </button>
 
-    <!-- 右：振り返り -->
-    <%= link_to "この日を振り返る",
-                reaction_path(date: @date),
-                data: { turbo_frame: "_top" },
-                class: "btn btn-primary btn-sm h-9 min-h-9 px-4 shadow-lg" %>
+  <!-- 右：振り返り -->
+  <%= link_to "この日を振り返る",
+              reaction_path(date: @date),
+              data: { turbo_frame: "_top" },
+              class: "btn btn-primary btn-sm h-9 min-h-9 px-4 shadow-lg" %>
 
-  </div>
 </div>
+


### PR DESCRIPTION
## 概要
calendar modal 内でログ件数が多い場合、  
ログ一覧とボタンの表示が重なり、視認性・操作性が低下する問題を修正しました。
ログが4件以上の場合はスクロールするようにし、ボタンと重ならないようにしつつ、
全体が常に表示されるようにしました。

---

## 対応Issue
- close #251 