### PR TITLE
【feat】 初回ログイン時に使い方説明ページに遷移するように変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,13 @@ class ApplicationController < ActionController::Base
   before_action :set_user
 
   def after_sign_in_path_for(resource)
-    home_path
+    session[:welcomed] = true
+
+    if resource.onboarding_completed?
+      home_path
+    else
+      onboarding_path
+    end
   end
 
   def after_sign_out_path_for(resource_or_scope)

--- a/app/controllers/onboardings_controller.rb
+++ b/app/controllers/onboardings_controller.rb
@@ -1,3 +1,13 @@
 class OnboardingsController < ApplicationController
+  before_action :complete_onboarding, only: :show
+
   def show;end
+
+  private
+
+  def complete_onboarding
+    return if current_user.onboarding_completed?
+
+    current_user.update!(onboarding_completed: true)
+  end
 end

--- a/db/migrate/20260106100654_add_onboarding_completed_to_users.rb
+++ b/db/migrate/20260106100654_add_onboarding_completed_to_users.rb
@@ -1,0 +1,5 @@
+class AddOnboardingCompletedToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :onboarding_completed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_12_14_123806) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_06_100654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -112,6 +112,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_12_14_123806) do
     t.string "name"
     t.string "provider"
     t.string "uid"
+    t.boolean "onboarding_completed", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## 概要
初回ログイン時のみ、使い方説明ページへ遷移するように変更しました。  
判定にはユーザーのカラムを使用しており、デバイスやログイン期間に依存せず一度きりの制御が可能です。

---

## 実装内容
- User モデルに `onboarding_completed` カラムを追加し、初回判定を boolean で管理
- `OnboardingsController` に `before_action :complete_onboarding` を追加し、初回アクセス時に `onboarding_completed` を `true` に更新
- `ApplicationController#after_sign_in_path_for` にて、`onboarding_completed` の状態に応じて遷移先を制御

---

## 対応Issue
- close #262