### PR TITLE
【feat】 ロード画面の実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -4,6 +4,7 @@
   --font-serif: "Noto Serif JP", ui-serif, serif;
 }
 @import "tailwindcss";
+@import "./loading.css";
 @plugin "daisyui" {
   themes: all;
   default: "kokolog-dark";

--- a/app/assets/stylesheets/loading.css
+++ b/app/assets/stylesheets/loading.css
@@ -1,0 +1,75 @@
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  pointer-events: none;
+
+  /* 空気感だけ変える */
+  background: rgba(255,255,255,0.02);
+  backdrop-filter: blur(2px) saturate(0.95);
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  transition: opacity 120ms ease-out;
+}
+
+.loading-overlay.hidden {
+  opacity: 0;
+}
+
+/* ===== Ripple ===== */
+
+.ripple-svg {
+  overflow: visible;
+}
+
+.ripple {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+
+  /* delay中は完全に存在しない */
+  opacity: 0;
+  transform: scale(0);
+
+  transform-box: fill-box;
+  transform-origin: center;
+
+  animation: ripple-scale 2.0s infinite ease-out;
+  animation-fill-mode: both;
+
+  /* 画面と馴染ませる */
+  mix-blend-mode: overlay;
+}
+
+/* 時間差 */
+.ripple-1 { animation-delay: 0s; }
+.ripple-2 { animation-delay: 0.15s; }
+.ripple-3 { animation-delay: 0.3s; }
+/* ===== Animation ===== */
+
+@keyframes ripple-scale {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+
+  /* 雫が落ちた瞬間 */
+  6% {
+    transform: scale(0.35);
+    opacity: 0.65;
+  }
+
+  /* 一気に外へ */
+  25% {
+    transform: scale(0.9);
+    opacity: 0.25;
+  }
+
+  100% {
+    transform: scale(1.25);
+    opacity: 0;
+  }
+}

--- a/app/javascript/controllers/global_loading_controller.js
+++ b/app/javascript/controllers/global_loading_controller.js
@@ -1,0 +1,54 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.overlay = document.getElementById("global-loading")
+
+    this.show = this.show.bind(this)
+    this.hide = this.hide.bind(this)
+
+    document.addEventListener("turbo:visit", this.show)
+    document.addEventListener("turbo:submit-start", this.show)
+
+    document.addEventListener("turbo:load", this.hide)
+    document.addEventListener("turbo:submit-end", this.hide)
+  }
+
+  // 表示は1回だけ
+  show() {
+    if (!this.overlay || this.startedAt) return
+
+    this.startedAt = Date.now()
+    this.overlay.classList.remove("hidden")
+
+    // フェードインが確実に走るように1フレーム待つ
+    requestAnimationFrame(() => {
+      this.overlay.classList.remove("opacity-0")
+      this.overlay.classList.add("opacity-100")
+    })
+  }
+
+  hide() {
+    if (!this.overlay || !this.startedAt) return
+
+    const elapsed = Date.now() - this.startedAt
+    const remaining = this.minDuration - elapsed
+
+    if (remaining > 0) {
+      setTimeout(() => this._hideNow(), remaining)
+    } else {
+      this._hideNow()
+    }
+  }
+
+  _hideNow() {
+    // フェードアウト
+    this.overlay.classList.remove("opacity-100")
+    this.overlay.classList.add("opacity-0")
+
+    setTimeout(() => {
+      this.overlay.classList.add("hidden")
+      this.startedAt = null
+    }, 300) // CSSのtransition時間と合わせる
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -39,3 +39,6 @@ application.register("parallax", ParallaxController)
 
 import MoodGraphController from "./mood_graph_controller"
 application.register("mood-graph", MoodGraphController)
+
+import GlobalLoadingController from "./global_loading_controller"
+application.register("global-loading", GlobalLoadingController)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,27 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
+  <!-- Global Ripple Loading -->
+  <div id="global-loading"
+      class="loading-overlay hidden">
+    <svg
+      class="ripple-svg"
+      width="160"
+      height="160"
+      viewBox="0 0 160 160"
+      aria-hidden="true"
+    >
+      <circle class="ripple ripple-1 text-primary"
+              cx="80" cy="80" r="70" />
+      <circle class="ripple ripple-2 text-accent"
+              cx="80" cy="80" r="70" />
+      <circle class="ripple ripple-3 text-base-content/25"
+              cx="80" cy="80" r="70" />
+    </svg>
+  </div>
+
   <body class="bg-base-200 min-h-screen flex flex-col font-sans"
+        data-controller="global-loading"
         style="
           background: linear-gradient(
             180deg,


### PR DESCRIPTION
## 概要
画面遷移時のUXを改善するため、**水面の雫→波紋をモチーフにしたグローバルローディング演出**を実装しました。  
短時間の遷移でも「ロードしている」ことが直感的に伝わるよう調整しています。

---

## 実装内容
- `app/views/layouts/application.html.erb`  
  - グローバルローディング用オーバーレイを追加
- `app/javascript/controllers/global_loading_controller.js`  
  - ローディングの表示／非表示を制御する Stimulus コントローラを実装
- `app/assets/stylesheets/application.tailwind.css`  
  - 波紋アニメーション（雫→波紋）およびオーバーレイ用スタイルを追加

---

## 対応Issue
- close #264 
