### PR TITLE
【feat】Moodモデルのspec追加

### DIFF
--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -1,6 +1,6 @@
 class Mood < ApplicationRecord
   # --- 関連 ---
-  has_many :mood_logs, dependent: :nullify
+  has_many :mood_logs
 
   # --- バリデーション ---
   validates :score, presence: true, uniqueness: true

--- a/spec/factories/moods.rb
+++ b/spec/factories/moods.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :mood do
+    sequence(:score) { |n| n }
+    sequence(:label) { |n| "Mood#{n}" }
+    color { "#ffffff" }
+  end
+end

--- a/spec/models/mood_spec.rb
+++ b/spec/models/mood_spec.rb
@@ -1,5 +1,45 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Mood, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "associations" do
+    it "has many mood_logs" do
+      assoc = described_class.reflect_on_association(:mood_logs)
+      expect(assoc.macro).to eq(:has_many)
+    end
+  end
+
+  describe "validations" do
+    it "is valid with required attributes" do
+      mood = build(:mood)
+      expect(mood).to be_valid
+    end
+
+    it "is invalid without score" do
+      mood = build(:mood, score: nil)
+      expect(mood).not_to be_valid
+    end
+
+    it "is invalid with duplicate score" do
+      create(:mood, score: 1)
+      mood = build(:mood, score: 1)
+      expect(mood).not_to be_valid
+    end
+
+    it "is invalid without label" do
+      mood = build(:mood, label: nil)
+      expect(mood).not_to be_valid
+    end
+
+    it "is invalid with duplicate label" do
+      create(:mood, label: "very good")
+      mood = build(:mood, label: "very good")
+
+      expect(mood).not_to be_valid
+    end
+
+    it "is invalid without color" do
+      mood = build(:mood, color: nil)
+      expect(mood).not_to be_valid
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,34 +4,29 @@ RSpec.describe User, type: :model do
   describe "validations" do
     it "is valid with all required attributes" do
       user = build(:user)
-
       expect(user).to be_valid
       expect(user.errors).to be_empty
     end
 
     it "is valid for google linked user" do
       user = build(:user, :google_linked)
-
       expect(user).to be_valid
       expect(user.errors).to be_empty
     end
 
     it "is invalid without email" do
       user = build(:user, email: nil)
-
       expect(user).not_to be_valid
     end
 
     it "is invalid with duplicate email" do
       create(:user, email: "test@example.com")
       user = build(:user, email: "test@example.com")
-
       expect(user).not_to be_valid
     end
 
     it "is invalid when password is too short" do
       user = build(:user, password: "12345")
-
       expect(user).not_to be_valid
     end
   end


### PR DESCRIPTION
## 概要
Moodモデルの設計変更に伴い、RSpec（model spec）を更新しました。  
Moodは必須のマスタデータとし、削除を前提としない設計に合わせて  
アソシエーションおよびバリデーションのテストを整理しています。

---

## 実装内容
- Moodモデルの`has_many :mood_logs` の関連を修正、`dependent: :nullify`を削除。
- Moodモデルの model spec を追加
  - `has_many :mood_logs` の関連を検証
  - Moodが必須属性（score / label / color）を持つことを検証
  - score・label の一意性バリデーションを検証
- FactoryBot を利用してテストデータを作成

---

## 実行結果
<img width="684" height="352" alt="image" src="https://github.com/user-attachments/assets/15eb5504-2b8e-47d0-ac5a-592307dba9c2" />

---

## 対応Issue
- close #268 