### PR TITLE
【test】Feelingモデルのspec追加

### DIFF
--- a/spec/factories/feelings.rb
+++ b/spec/factories/feelings.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :feeling do
+    sequence(:name) { |n| "name#{n}"  }
+  end
+end

--- a/spec/models/feeling_spec.rb
+++ b/spec/models/feeling_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Feeling, type: :model do
+  describe "associations" do
+    it "has many mood_logs with dependent nullify" do
+      assoc = described_class.reflect_on_association(:mood_logs)
+
+      expect(assoc.macro).to eq(:has_many)
+      expect(assoc.options[:dependent]).to eq(:nullify)
+    end
+  end
+
+  describe "validations" do
+    it "is valid with name" do
+      feeling = build(:feeling)
+
+      expect(feeling).to be_valid
+      expect(feeling.errors).to be_empty
+    end
+
+    it "is invalid without name" do
+      feeling = build(:feeling, name: nil)
+
+      expect(feeling).not_to be_valid
+    end
+
+    it "is invalid with duplicate name" do
+      create(:feeling, name: "Calm")
+      feeling = build(:feeling, name: "Calm")
+
+      expect(feeling).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Feeling モデルに対する RSpec を新規作成しました。

---

## 実装内容
- Feeling モデルの association を検証する RSpec を追加
  - `has_many :mood_logs`
  - `dependent: :nullify`
- Feeling モデルの validation を検証する RSpec を追加
  - `name` の presence
  - `name` の uniqueness
- テストデータ生成に FactoryBot を使用

---

## 実行結果
<img width="712" height="277" alt="image" src="https://github.com/user-attachments/assets/dc1f9542-857c-4d95-8ea0-04cf09d4958c" />
---

## 対応Issue
- close #270