### PR TITLE
【fix】PumaとDBコネクションプールの設定を見直し

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: 1
   host: db # compose.ymlで定義したサービス名
   username: postgres  # 接続ユーザー名
   password: password  # 接続パスワード（database.yml のパスワードと一致）
@@ -19,3 +19,4 @@ test:
 production:
     <<: *default
     url: <%= ENV['DATABASE_URL'] %>
+    pool: 1

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,34 +1,7 @@
-# This configuration file will be evaluated by Puma. The top-level methods that
-# are invoked here are part of Puma's configuration DSL. For more information
-# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
+threads 1, 1
 
-# Puma starts a configurable number of processes (workers) and each process
-# serves each request in a thread from an internal thread pool.
-#
-# The ideal number of threads per worker depends both on how much time the
-# application spends waiting for IO operations and on how much you wish to
-# to prioritize throughput over latency.
-#
-# As a rule of thumb, increasing the number of threads will increase how much
-# traffic a given process can handle (throughput), but due to CRuby's
-# Global VM Lock (GVL) it has diminishing returns and will degrade the
-# response time (latency) of the application.
-#
-# The default is set to 3 threads as it's deemed a decent compromise between
-# throughput and latency for the average Rails application.
-#
-# Any libraries that use a connection pool or another resource pool should
-# be configured to provide at least as many connections as the number of
-# threads. This includes Active Record's `pool` parameter in `database.yml`.
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
-threads threads_count, threads_count
-
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 port ENV.fetch("PORT", 3000)
 
-# Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-# Specify the PID file. Defaults to tmp/pids/server.pid in development.
-# In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]


### PR DESCRIPTION
## 概要
本番環境において、少人数の同時アクセスでもレスポンスが極端に遅延し、
場合によっては 502 エラーが発生していた問題を修正しました。

Puma の並列設定と DB コネクションプールの設定が
利用している DB（Neon）の特性と合っていなかったことが原因のため、
本番環境の安定性を優先した設定に見直しています。

---

## 発生していた問題
- 同時に複数ユーザーが操作するとレスポンスが数十秒〜数分かかる
- リクエストが詰まり、502 Bad Gateway が発生することがある
- ActiveRecord のクエリ数は少ないにも関わらず、View 時間が異常に長くなる

---

## 原因
- Puma が複数スレッドで同時リクエストを処理しようとしていた
- `database.yml` で DB コネクションプール数が `RAILS_MAX_THREADS` に依存しており、
  本番環境で実際の DB 許容接続数を超えていた
- 使用している DB（Neon）は同時接続数に制限があり、
  DB コネクション待ちが発生してリクエスト全体が詰まっていた

---

## 対応内容
- Puma のスレッド数を 1 に固定し、同時処理数を制限
- DB コネクションプール数を 1 に明示的に設定
- Puma と ActiveRecord の接続数を一致させ、競合を防止

---

## 今後の対応
- この設定で様子見し、場合によっては再調整する
- 改善が見られない場合、他の原因を調査し、修正する