### PR TITLE
【refactor】 N+1の回避

### DIFF
--- a/app/models/habit_log.rb
+++ b/app/models/habit_log.rb
@@ -29,10 +29,12 @@ class HabitLog < ApplicationRecord
   end
 
   def before_mood_log
+    return mood_logs.detect(&:before?) if mood_logs.loaded?
     mood_logs.before.first
   end
 
   def after_mood_log
+    return mood_logs.detect(&:after?) if mood_logs.loaded?
     mood_logs.after.first
   end
 

--- a/app/queries/habit_logs_query.rb
+++ b/app/queries/habit_logs_query.rb
@@ -19,6 +19,11 @@ class HabitLogsQuery
   end
 
   def logs
-    @logs ||= @user.habit_logs.where(started_at: range)
+    @logs ||= @user.habit_logs
+      .includes(
+        habit: [ :goal, :category ],
+        mood_logs: [ :mood ]
+      )
+      .where(started_at: range)
   end
 end


### PR DESCRIPTION
## 概要
Bulletの「AVOID eager loading」警告を減らし、N+1の疑いを解消しました。

---

## 変更内容
- `HabitLog#before_mood_log` / `after_mood_log` を、`mood_logs` がロード済みならメモリ上で抽出するように変更
- `HabitLogsQuery` の includes から不要な関連（例: mood_logs の feeling など）を整理

---

## 対応Issue
- close #276 