### PR TITLE
【test】Categoryモデルのspec追加

### DIFF
--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "Category#{n}" }
+    icon { "icon" }
+    description { "description" }
+  end
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Category, type: :model do
+  describe "associations" do
+    it "has many habits with dependent nullify" do
+      assoc = described_class.reflect_on_association(:habits)
+
+      expect(assoc.macro).to eq(:has_many)
+      expect(assoc.options[:dependent]).to eq(:nullify)
+    end
+  end
+
+  describe "validations" do
+    it "is valid with required attributes" do
+      category = build(:category)
+
+      expect(category).to be_valid
+      expect(category.errors).to be_empty
+    end
+
+    it "is invalid without name" do
+      category = build(:category, name: nil)
+
+      expect(category).not_to be_valid
+    end
+
+    it "is invalid with duplicate name" do
+      create(:category, name: "Study")
+      category = build(:category, name: "Study")
+
+      expect(category).not_to be_valid
+    end
+
+    it "is invalid when icon is too long" do
+      category = build(:category, icon: "a" * 11)
+      expect(category).not_to be_valid
+    end
+
+    it "is valid with blank description" do
+      category = build(:category, description: "")
+      expect(category).to be_valid
+    end
+
+    it "is invalid when description is too long" do
+      category = build(:category, description: "a" * 201)
+      expect(category).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## 概要
Category モデルに対する RSpec を新規作成しました。

---

## 実装内容
- Category モデルの association を検証する RSpec を追加
  - `has_many :habits`
  - `dependent: :nullify`
- Category モデルの validation を検証する RSpec を追加
  - `name` の presence
  - `name` の uniqueness
  - `icon` の文字数制限
  - `description` の文字数制限
  - `description` が空文字でも有効であること
- テストデータ生成に FactoryBot を使用

---

## 実行結果
<img width="435" height="232" alt="image" src="https://github.com/user-attachments/assets/fd587051-aed6-4a25-a3a2-d44185c86768" />

---

## 対応Issue
- close #280