### PR TITLE
【chore】 メール配信設定をSMTPからResend APIに変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem "cssbundling-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 
+# mailer
+gem "resend"
+
 # 🔐 Authentication
 gem "devise", "~> 4.9"
 gem "devise-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.5)
     date (3.4.1)
     debug (1.11.0)
       irb (~> 1.10)
@@ -161,6 +162,10 @@ GEM
     hashie (5.0.0)
     heroicon (1.0.0)
       rails (>= 5.2)
+    httparty (0.24.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     image_processing (1.14.0)
@@ -348,6 +353,8 @@ GEM
     regexp_parser (2.11.3)
     reline (0.6.2)
       io-console (~> 0.5)
+    resend (1.0.0)
+      httparty (>= 0.21.0)
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
@@ -499,6 +506,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.2)
   rails-i18n
+  resend
   rspec-rails
   rubocop-rails-omakase
   selenium-webdriver

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,22 +78,13 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
-  # === Action Mailer (Gmail SMTP) ===
-  config.action_mailer.delivery_method = :smtp
-
-  config.action_mailer.smtp_settings = {
-    address: "smtp.gmail.com",
-    port: 587,
-    user_name: ENV["GMAIL_USERNAME"],
-    password: ENV["GMAIL_APP_PASSWORD"],
-    authentication: "plain",
-    enable_starttls_auto: true
-  }
+  # === Action Mailer (Resend) ===
+  config.action_mailer.delivery_method = :resend
 
   config.action_mailer.default_url_options = {
-  host: "kocolog.com",
-  protocol: "https"
-}
+    host: "kocolog.com",
+    protocol: "https"
+  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
@@ -115,6 +106,7 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts << "kocolog.com"      # 独自ドメイン
   config.hosts << "www.kocolog.com"  # サブドメイン
+  config.hosts << "kokolog.onrender.com"      # 旧ドメイン
 
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,2 @@
+require "resend"
+Resend.api_key = ENV["RESEND_API_KEY"]


### PR DESCRIPTION
## 概要
Render の無料枠では SMTP 通信に制限があり、本番環境において
パスワード再設定メール送信時にタイムアウトが発生することが判明しました。

そこで、SMTP によるメール送信を廃止し、
HTTP API ベースで安定して利用可能な Resend API に切り替えることで、
本番環境でのメール送信を安定させました。

---

## 実装内容
- SMTP を利用した ActionMailer の設定を削除
- メール配信手段を Resend API に切り替え
- メール送信フローは引き続き Devise に委譲し、責務を変更しない構成とした
- 送信元メールアドレスは Devise の `mailer_sender` で一元管理
- 本番環境において SMTP タイムアウトが発生しないことを確認

---

## 変更理由
- Render 無料枠では SMTP 通信に制限があり、安定した運用が困難なため
- Resend API は HTTP ベースであり、Render 環境でも安定して利用可能なため
- Devise の既存フローを崩さず、配信手段のみを差し替えることで影響範囲を最小化するため

---

## 動作確認
- 本番環境でパスワード再設定メールを送信し、正常に受信できることを確認
- Render のログにてタイムアウトおよび SMTP 関連エラーが発生しないことを確認

---

## 対応Issue
- close #70