### PR TITLE
【fix】 ホーム画面のN+1問題と習慣登録時にチェック状態だと保存できない問題を修正

### DIFF
--- a/app/forms/habit_form.rb
+++ b/app/forms/habit_form.rb
@@ -33,8 +33,11 @@ class HabitForm
   validates :goal_unit, :frequency, presence: true
   validates :status, presence: true
 
-  # amount は 1以上
-  validates :amount, numericality: { greater_than: 0 }
+  # amount は count / time の場合だけ1以上
+  # check_based の場合は後から自動設定
+  validates :amount,
+  numericality: { greater_than: 0 },
+  if: -> { goal_unit.in?(%w[count_based time_based]) }
 
   # 日付チェック
   validate :start_date_must_be_before_end_date

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -18,10 +18,7 @@ class Goal < ApplicationRecord
   validates :amount, presence: true
 
   # count / time の場合だけ amount が必要
-  validates :amount,
-    numericality: { greater_than: 0 },
-    if: -> { goal_unit.in?(%w[count_based time_based]) }
-
+  validates :amount, numericality: { greater_than: 0 }
   validate :start_date_must_be_before_end_date
 
   # --- scope ---

--- a/app/queries/habit_query.rb
+++ b/app/queries/habit_query.rb
@@ -12,9 +12,9 @@ class HabitQuery
     @active_base ||= begin
       Habit
         .where(user: @user, archived_at: nil)
-        .joins(:goal)
+        .joins(:goal, :category)
         .merge(Goal.active.effective_on(@date))
-        .includes(:goal)
+        .includes(:goal, :category)
         .distinct
         .to_a
     end


### PR DESCRIPTION
## 概要

ホーム画面における N+1 クエリ問題を修正しました。  
あわせて、習慣登録時に `goal_unit` が「チェック」の場合、`amount` が `nil` のままだと
本来は自動入力される想定にもかかわらず、バリデーションエラーにより保存できなかった問題を修正しました。

パフォーマンス改善と、ユーザー操作時の不整合解消を目的とした対応です。

---

## 実装内容

- ホーム画面表示時の N+1 クエリを解消
  - 関連データの eager loading を適切に追加
  - 不要なクエリ発行を抑制し、パフォーマンスを改善
- 習慣登録処理の修正
  - `goal_unit` がチェック形式の場合、`amount` が `nil` でも保存できるように修正
  - 自動補完ロジックとバリデーションの不整合を解消

---

## 動作確認

- ホーム画面表示時のクエリ数が増加しないことを確認
- 習慣登録時に以下のケースで正常に保存できることを確認
  - `goal_unit = check`
  - `amount = nil`

---

## 対応 Issue

- close #296